### PR TITLE
fix: jellyfin MediaStreams field & organize confirm prompt swallowed by Rich Progress

### DIFF
--- a/pavone/jellyfin/client.py
+++ b/pavone/jellyfin/client.py
@@ -372,7 +372,7 @@ class JellyfinClientWrapper:
                         "ParentId": lib_id,
                         "Filters": "IsNotFolder",
                         "IncludeItemTypes": "Movie,Video",
-                        "Fields": "Path,DateCreated,Overview,Genres,People,Studios,Tags,CommunityRating,OfficialRating,MediaSources",
+                        "Fields": "Path,DateCreated,Overview,Genres,People,Studios,Tags,CommunityRating,OfficialRating,MediaSources,MediaStreams",
                         "Limit": limit,
                         "StartIndex": start_index,
                         "Recursive": True,

--- a/pavone/manager/execution.py
+++ b/pavone/manager/execution.py
@@ -651,8 +651,14 @@ class ExecutionManager:
         Returns:
             处理后的进度回调函数
         """
-        # 只有当下载类型为STREAM或者VIDEO时才传递进度回调
-        if selected_item.item_type in (ItemType.STREAM, ItemType.VIDEO):
+        # 只有当操作为 DOWNLOAD 且 item 类型为 STREAM/VIDEO 时才创建进度回调.
+        # MOVE 等非下载操作不会使用进度回调, 而 Rich Progress 一旦 start() 就会接管 stdout,
+        # 若没有对应的 stop() 调用会导致后续 click.confirm/prompt 输出被吞掉
+        # (organize 多文件场景下第二次起确认提示不显示的根因).
+        if selected_item.opt_type == OperationType.DOWNLOAD and selected_item.item_type in (
+            ItemType.STREAM,
+            ItemType.VIDEO,
+        ):
             if selected_item.item_type == ItemType.STREAM:
                 # M3U8: 使用分片级进度回调
                 callback = create_segment_progress_callback() if not silent else create_silent_progress_callback()


### PR DESCRIPTION
## Summary

本 PR 包含两个相关修复:

### 1. fix(jellyfin): include MediaStreams field when querying library items (`973a5a7`)
查询 Jellyfin 库 items 时, 在 `Fields` 参数中增加 `MediaStreams`, 以便后续能拿到媒体流详情 (分辨率等).

### 2. fix(organize): show confirm prompt for every file in batch (`6aba01b`)
**问题**: `pavone organize` 在多文件场景下, 第二个文件起 "是否执行整理?" 确认提示不显示, 但程序仍在阻塞等待输入.

**根因**: `ExecutionManager._set_progress_callback` 仅根据 `item_type` (VIDEO/STREAM) 判断是否创建 Rich `Progress`. 但 organize 的根 MOVE 操作的 `item_type=VIDEO`, 会创建 Rich Progress 并调用 `start()`. 而 `FileMover` 不调用 progress callback, 也就没有对应的 `stop()`, 导致 Rich Live 持续接管 stdout, 后续 `click.confirm` 写出的提示文本被吞掉.

**修复**: 在 `_set_progress_callback` 中追加 `opt_type == DOWNLOAD` 判断, MOVE 等非下载操作不再创建进度回调.

## Verification
- 编写脚本复现了 bug 并验证修复后提示正常显示
- `uv run pytest tests/ -k "execution or progress or organize or m3u8"` 全部 29 个相关测试通过
