### PR TITLE
chore: regenerate auto-release workflow lock file

### DIFF
--- a/.github/workflows/auto-release.lock.yml
+++ b/.github/workflows/auto-release.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0f0cdd6e6d2f38a51138a54ba073dcdf9a2b68cd72a2d6b240d88090965e8e2f","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"01080d91a1d1aa96c36b7ed199f057c0aaf162eedb305214df757807cec007de","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"11bd71901bbe5b1630ceea73d27597364c9af683","version":"11bd71901bbe5b1630ceea73d27597364c9af683"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-python","sha":"42375524e23c412d93fb67b49958b491fce71c38","version":"42375524e23c412d93fb67b49958b491fce71c38"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -177,14 +177,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e542ab9ea0d24b29_EOF'
+          cat << 'GH_AW_PROMPT_357213551eabde23_EOF'
           <system>
-          GH_AW_PROMPT_e542ab9ea0d24b29_EOF
+          GH_AW_PROMPT_357213551eabde23_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e542ab9ea0d24b29_EOF'
+          cat << 'GH_AW_PROMPT_357213551eabde23_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, bump_version_and_release
           </safe-output-tools>
@@ -216,12 +216,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e542ab9ea0d24b29_EOF
+          GH_AW_PROMPT_357213551eabde23_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e542ab9ea0d24b29_EOF'
+          cat << 'GH_AW_PROMPT_357213551eabde23_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-release.md}}
-          GH_AW_PROMPT_e542ab9ea0d24b29_EOF
+          GH_AW_PROMPT_357213551eabde23_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -391,9 +391,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_00d5eac727b8253f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f68ffaece2b59567_EOF'
           {"bump-version-and-release":{"description":"Bump version in pyproject.toml based on PR labels and create a GitHub release","output":"Version bumped and release created!"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_00d5eac727b8253f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f68ffaece2b59567_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -563,7 +563,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_950aabc712d47299_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_6146891d47671256_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -604,7 +604,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_950aabc712d47299_EOF
+          GH_AW_MCP_CONFIG_6146891d47671256_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -874,6 +874,9 @@ jobs:
 
           # Update pyproject.toml
           sed -i "s/version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" pyproject.toml
+
+          # Update pavone/__init__.py
+          sed -i "s/__version__ = \"$CURRENT\"/__version__ = \"$NEW_VERSION\"/" pavone/__init__.py
         env:
           BUMP_TYPE_INPUT: ${{ steps.check.outputs.bump_type }}
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
@@ -882,8 +885,8 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           RELEASE_NOTES=$(cat /tmp/release_notes.md)
 
-          # Prepend new version entry after the header
-          sed -i "/^## \[/i ## [$NEW_VERSION] - $DATE\n\n$RELEASE_NOTES\n" CHANGELOG.md
+          # Prepend new version entry after the header (only before the first ## [ line)
+          sed -i "0,/^## \[/s//## [$NEW_VERSION] - $DATE\n\n$RELEASE_NOTES\n\n&/" CHANGELOG.md
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
@@ -891,7 +894,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml CHANGELOG.md
+          git add pyproject.toml pavone/__init__.py CHANGELOG.md
           git commit -m "chore: bump version to $NEW_VERSION" || echo "No changes to commit"
           git tag "v$NEW_VERSION"
           git push origin main --tags
@@ -899,7 +902,7 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
       - name: Create GitHub Release
-        run: |-
+        run: |
           RELEASE_TITLE="$RELEASE_TITLE_INPUT"
           if [ -z "$RELEASE_TITLE" ]; then
             RELEASE_TITLE="v$NEW_VERSION"

--- a/uv.lock
+++ b/uv.lock
@@ -1381,7 +1381,7 @@ wheels = [
 
 [[package]]
 name = "pavone"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

修复 PR #23 合并时 Auto Version Bump and Release workflow 失败的问题:

```
ERR_CONFIG: Lock file '.github/workflows/auto-release.lock.yml' is outdated!
The workflow file '.github/workflows/auto-release.md' frontmatter has changed.
Run 'gh aw compile' to regenerate the lock file.
```

## Changes

- 运行 `gh aw compile` 重新生成 `.github/workflows/auto-release.lock.yml` 以匹配 `auto-release.md` 的 frontmatter (gh-aw 工具的 lock 文件机制)
- 顺带同步 `uv.lock` 中 pavone 自身版本 0.3.4  0.3.5, 与 `pyproject.toml` 保持一致

## Verification

`gh aw compile` 输出: 0 error(s), 0 warning(s)
