### PR TITLE
feat(organize): handle duplicate codes and improve metadata providers

### DIFF
--- a/pavone/cli/commands/organize.py
+++ b/pavone/cli/commands/organize.py
@@ -2,6 +2,7 @@
 Organize command - 整理命令
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
@@ -14,7 +15,31 @@ from ...manager.plugin_manager import get_plugin_manager
 from ...manager.search_manager import get_search_manager
 from ...utils.file_operation_builder import FileOperationBuilder
 from ...utils.filename_parser import FilenameParser
+from ...utils.format_utils import FormatUtils
 from .utils import confirm_action, echo_error, echo_info, echo_success, echo_warning
+
+
+# 支持的视频扩展名
+VIDEO_EXTENSIONS = {
+    ".mp4", ".mkv", ".avi", ".wmv", ".flv", ".mov",
+    ".rmvb", ".m4v", ".mpg", ".mpeg", ".ts", ".webm", ".3gp",
+}
+
+
+@dataclass
+class LocalVideoQuality:
+    """本地视频文件质量信息"""
+
+    path: str
+    filename: str
+    size: str
+    size_bytes: int
+    resolution: str
+    height: int
+    bitrate: str
+    bitrate_raw: int
+    codec: str
+    duration: str
 
 
 @click.command()
@@ -183,7 +208,62 @@ def organize(
                     continue
 
                 target_path = operation.get_target_path()
+                if not target_path:
+                    echo_error("  无法确定目标路径")
+                    failed_count += 1
+                    continue
                 echo_info(f"  目标路径: {target_path}")
+
+                # 4.5 检查目标文件夹是否已有同番号视频
+                target_path_obj = Path(target_path)
+                target_dir = target_path_obj.parent
+                existing_videos = _find_existing_videos(target_dir, exclude=video_file)
+
+                if existing_videos:
+                    echo_warning(f"  目标文件夹已存在 {len(existing_videos)} 个视频文件:")
+
+                    source_quality = _probe_video_quality(video_file)
+                    existing_qualities = [_probe_video_quality(v) for v in existing_videos]
+                    _display_quality_comparison(source_quality, existing_qualities)
+
+                    if auto:
+                        echo_warning("  自动模式: 跳过已存在的番号")
+                        skipped_count += 1
+                        continue
+
+                    action = _prompt_duplicate_action()
+
+                    if action == "skip":
+                        echo_warning("  跳过")
+                        skipped_count += 1
+                        continue
+                    elif action == "extra":
+                        # 移动到 extras 子文件夹（Jellyfin 支持的 extras 目录）
+                        # 保留源文件原始文件名
+                        extras_dir = target_dir / "extras"
+                        new_target = extras_dir / video_file.name
+                        operation.set_target_path(str(new_target))
+                        # extras 不需要 NFO/封面等子操作
+                        operation._children.clear()
+                        echo_info(f"  将作为 Extra 移动到: {new_target}")
+                    else:
+                        # overwrite: 目标路径使用原始无后缀路径
+                        original_target = target_dir / (target_path_obj.stem.split(" (")[0] + target_path_obj.suffix)
+                        operation.set_target_path(str(original_target))
+
+                        # 删除已有视频文件
+                        for existing in existing_videos:
+                            if not dry_run:
+                                existing.unlink()
+                                echo_info(f"  已删除旧文件: {existing.name}")
+                            else:
+                                echo_info(f"  [模拟] 将删除: {existing.name}")
+
+                        # 询问是否重新生成元信息文件
+                        if operation.has_children():
+                            if not confirm_action("  目标已有元信息文件，是否重新生成 NFO/封面等？", default=False):
+                                operation._children.clear()
+                                echo_info("  保留已有元信息文件")
 
                 # 5. 显示操作详情
                 if operation.has_children():
@@ -192,7 +272,7 @@ def organize(
                         echo_info(f"    - {child.get_description()}")
 
                 # 6. 确认执行（非自动模式）
-                if not auto and not dry_run:
+                if not auto and not dry_run and not existing_videos:
                     if not confirm_action("  是否执行整理？", default=True):
                         echo_warning("  跳过")
                         skipped_count += 1
@@ -327,37 +407,18 @@ def _scan_video_files(path: str, recursive: bool) -> List[Path]:
     path_obj = Path(path)
     video_files: List[Path] = []
 
-    # 支持的视频扩展名
-    video_extensions = {
-        ".mp4",
-        ".mkv",
-        ".avi",
-        ".wmv",
-        ".flv",
-        ".mov",
-        ".rmvb",
-        ".m4v",
-        ".mpg",
-        ".mpeg",
-        ".ts",
-        ".webm",
-        ".3gp",
-    }
-
     if path_obj.is_file():
         # 单个文件
-        if path_obj.suffix.lower() in video_extensions:
+        if path_obj.suffix.lower() in VIDEO_EXTENSIONS:
             video_files.append(path_obj)
     else:
         # 目录
         if recursive:
-            # 递归扫描
-            for ext in video_extensions:
+            for ext in VIDEO_EXTENSIONS:
                 video_files.extend(path_obj.rglob(f"*{ext}"))
                 video_files.extend(path_obj.rglob(f"*{ext.upper()}"))
         else:
-            # 仅扫描当前目录
-            for ext in video_extensions:
+            for ext in VIDEO_EXTENSIONS:
                 video_files.extend(path_obj.glob(f"*{ext}"))
                 video_files.extend(path_obj.glob(f"*{ext.upper()}"))
 
@@ -365,3 +426,194 @@ def _scan_video_files(path: str, recursive: bool) -> List[Path]:
     video_files = sorted(set(video_files))
 
     return video_files
+
+
+def _find_existing_videos(target_dir: Path, exclude: Optional[Path] = None) -> List[Path]:
+    """检查目标文件夹中是否已有视频文件
+
+    Args:
+        target_dir: 目标目录
+        exclude: 排除的文件路径（避免把源文件自身当作重复）
+
+    Returns:
+        已存在的视频文件列表
+    """
+    if not target_dir.exists():
+        return []
+
+    existing: List[Path] = []
+    exclude_resolved = exclude.resolve() if exclude else None
+
+    for f in target_dir.iterdir():
+        if f.is_file() and f.suffix.lower() in VIDEO_EXTENSIONS:
+            if exclude_resolved and f.resolve() == exclude_resolved:
+                continue
+            existing.append(f)
+
+    return sorted(existing)
+
+
+def _probe_video_quality(file_path: Path) -> LocalVideoQuality:
+    """探测本地视频文件质量信息
+
+    优先使用 ffprobe 获取详细信息，不可用时回退到仅文件大小。
+
+    Args:
+        file_path: 视频文件路径
+
+    Returns:
+        LocalVideoQuality 对象
+    """
+    import json
+    import shutil
+    import subprocess
+
+    size_bytes = file_path.stat().st_size
+
+    # 尝试 ffprobe
+    if shutil.which("ffprobe"):
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe", "-v", "quiet",
+                    "-print_format", "json",
+                    "-show_streams", "-show_format",
+                    str(file_path),
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=30,
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                video_stream = next(
+                    (s for s in data.get("streams", []) if s.get("codec_type") == "video"),
+                    None,
+                )
+                fmt = data.get("format", {})
+
+                if video_stream:
+                    width = int(video_stream.get("width", 0))
+                    height = int(video_stream.get("height", 0))
+                    codec = video_stream.get("codec_name", "未知")
+                    bitrate_raw = int(video_stream.get("bit_rate", 0) or fmt.get("bit_rate", 0) or 0)
+                    duration_sec = float(fmt.get("duration", 0))
+
+                    return LocalVideoQuality(
+                        path=str(file_path),
+                        filename=file_path.name,
+                        size=FormatUtils.format_size(size_bytes),
+                        size_bytes=size_bytes,
+                        resolution=f"{width}x{height}" if width and height else "未知",
+                        height=height,
+                        bitrate=FormatUtils.format_bitrate(bitrate_raw) if bitrate_raw else "未知",
+                        bitrate_raw=bitrate_raw,
+                        codec=codec,
+                        duration=f"{int(duration_sec // 60)} 分钟" if duration_sec else "未知",
+                    )
+        except Exception:
+            pass
+
+    # 回退：仅文件大小
+    return LocalVideoQuality(
+        path=str(file_path),
+        filename=file_path.name,
+        size=FormatUtils.format_size(size_bytes),
+        size_bytes=size_bytes,
+        resolution="未知 (需要 ffprobe)",
+        height=0,
+        bitrate="未知",
+        bitrate_raw=0,
+        codec="未知",
+        duration="未知",
+    )
+
+
+def _display_quality_comparison(
+    source: LocalVideoQuality,
+    existing_list: List[LocalVideoQuality],
+) -> None:
+    """显示新文件与已有文件的质量对比
+
+    Args:
+        source: 新文件的质量信息
+        existing_list: 已有文件的质量信息列表
+    """
+    click.echo()
+    click.echo("  " + "─" * 56)
+
+    # 新文件信息
+    click.secho("  【新文件】", fg="cyan", bold=True)
+    click.echo(f"    文件名:  {source.filename}")
+    click.echo(f"    大小:    {source.size}")
+    click.echo(f"    分辨率:  {source.resolution}")
+    click.echo(f"    编码:    {source.codec}")
+    click.echo(f"    码率:    {source.bitrate}")
+    click.echo(f"    时长:    {source.duration}")
+
+    click.echo("  " + "─" * 56)
+
+    # 已有文件信息
+    for i, existing in enumerate(existing_list):
+        label = "【已有文件】" if len(existing_list) == 1 else f"【已有文件 {i + 1}】"
+        click.secho(f"  {label}", fg="yellow", bold=True)
+        click.echo(f"    文件名:  {existing.filename}")
+        click.echo(f"    大小:    {existing.size}")
+        click.echo(f"    分辨率:  {existing.resolution}")
+        click.echo(f"    编码:    {existing.codec}")
+        click.echo(f"    码率:    {existing.bitrate}")
+        click.echo(f"    时长:    {existing.duration}")
+
+    click.echo("  " + "─" * 56)
+
+    # 质量建议
+    best_existing_height = max(e.height for e in existing_list)
+    if source.height > 0 and best_existing_height > 0:
+        if source.height > best_existing_height:
+            click.secho("  建议: 新文件质量更高", fg="green", bold=True)
+        elif source.height < best_existing_height:
+            click.secho("  建议: 已有文件质量更高", fg="red", bold=True)
+        else:
+            # 分辨率相同，比较文件大小（通常更大 = 更高码率）
+            best_existing_size = max(e.size_bytes for e in existing_list)
+            if source.size_bytes > best_existing_size * 1.1:
+                click.secho("  建议: 分辨率相同，新文件码率可能更高", fg="green")
+            elif source.size_bytes < best_existing_size * 0.9:
+                click.secho("  建议: 分辨率相同，已有文件码率可能更高", fg="yellow")
+            else:
+                click.secho("  建议: 质量基本相同", fg="white")
+    elif source.height == 0 and best_existing_height == 0:
+        # 都无法获取分辨率，比较文件大小
+        best_existing_size = max(e.size_bytes for e in existing_list)
+        if source.size_bytes > best_existing_size:
+            click.secho(f"  提示: 新文件更大 ({source.size} vs {FormatUtils.format_size(best_existing_size)})", fg="cyan")
+        else:
+            click.secho(
+                f"  提示: 已有文件更大 ({FormatUtils.format_size(best_existing_size)} vs {source.size})", fg="cyan"
+            )
+
+    click.echo()
+
+
+def _prompt_duplicate_action() -> str:
+    """提示用户选择同番号冲突的处理方式
+
+    Returns:
+        "skip" / "overwrite" / "extra"
+    """
+    click.echo("  请选择处理方式:")
+    click.echo("    [S] 跳过 - 不处理此文件")
+    click.echo("    [O] 覆盖 - 删除已有文件，移入新文件")
+    click.echo("    [E] Extra - 作为 Jellyfin Extra 移入 extras/ 子文件夹")
+
+    while True:
+        choice = click.prompt("  请输入", type=str, default="S").strip().upper()
+        if choice in ("S", "SKIP"):
+            return "skip"
+        elif choice in ("O", "OVERWRITE"):
+            return "overwrite"
+        elif choice in ("E", "EXTRA"):
+            return "extra"
+        else:
+            click.echo("  无效输入，请输入 S / O / E")

--- a/pavone/cli/commands/organize.py
+++ b/pavone/cli/commands/organize.py
@@ -18,11 +18,21 @@ from ...utils.filename_parser import FilenameParser
 from ...utils.format_utils import FormatUtils
 from .utils import confirm_action, echo_error, echo_info, echo_success, echo_warning
 
-
 # 支持的视频扩展名
 VIDEO_EXTENSIONS = {
-    ".mp4", ".mkv", ".avi", ".wmv", ".flv", ".mov",
-    ".rmvb", ".m4v", ".mpg", ".mpeg", ".ts", ".webm", ".3gp",
+    ".mp4",
+    ".mkv",
+    ".avi",
+    ".wmv",
+    ".flv",
+    ".mov",
+    ".rmvb",
+    ".m4v",
+    ".mpg",
+    ".mpeg",
+    ".ts",
+    ".webm",
+    ".3gp",
 }
 
 
@@ -475,9 +485,13 @@ def _probe_video_quality(file_path: Path) -> LocalVideoQuality:
         try:
             result = subprocess.run(
                 [
-                    "ffprobe", "-v", "quiet",
-                    "-print_format", "json",
-                    "-show_streams", "-show_format",
+                    "ffprobe",
+                    "-v",
+                    "quiet",
+                    "-print_format",
+                    "json",
+                    "-show_streams",
+                    "-show_format",
                     str(file_path),
                 ],
                 capture_output=True,
@@ -589,9 +603,7 @@ def _display_quality_comparison(
         if source.size_bytes > best_existing_size:
             click.secho(f"  提示: 新文件更大 ({source.size} vs {FormatUtils.format_size(best_existing_size)})", fg="cyan")
         else:
-            click.secho(
-                f"  提示: 已有文件更大 ({FormatUtils.format_size(best_existing_size)} vs {source.size})", fg="cyan"
-            )
+            click.secho(f"  提示: 已有文件更大 ({FormatUtils.format_size(best_existing_size)} vs {source.size})", fg="cyan")
 
     click.echo()
 

--- a/pavone/models/constants.py
+++ b/pavone/models/constants.py
@@ -112,6 +112,7 @@ class ImageExtraKeys:
 
     IMAGE_SIZE = "image_size"  # 图片尺寸, 如 1920x1080
     IMAGE_FORMAT = "image_format"  # 图片格式, 如 JPEG, PNG 等
+    BACKDROP_INDEX = "backdrop_index"  # 背景图序号 (0=无后缀, 1=backdrop1, 2=backdrop2...)
 
 
 class MetadataExtraKeys:

--- a/pavone/models/operation.py
+++ b/pavone/models/operation.py
@@ -358,7 +358,10 @@ class OperationItem:
             elif sub_type == ItemSubType.THUMBNAIL:
                 return f"-thumbnail{extension}"
             elif sub_type == ItemSubType.BACKDROP:
-                return f"-backdrop{extension}"
+                # Jellyfin 规范: backdrop.jpg, backdrop1.jpg, backdrop2.jpg ...
+                idx = self._extra.get(ImageExtraKeys.BACKDROP_INDEX, 0)
+                idx_suffix = str(idx) if idx > 0 else ""
+                return f"-backdrop{idx_suffix}{extension}"
             elif sub_type == ItemSubType.LANDSCAPE:
                 return f"-landscape{extension}"
             else:

--- a/pavone/plugins/jtable_plugin.py
+++ b/pavone/plugins/jtable_plugin.py
@@ -9,6 +9,8 @@ import re
 from datetime import datetime
 from typing import Any, List, Optional, Tuple
 
+import requests
+
 from ..models import MovieMetadata, OperationItem, Quality
 from ..utils import CodeExtractUtils, StringUtils
 from ..utils.html_metadata_utils import (
@@ -63,6 +65,38 @@ class JTablePlugin(ExtractorPlugin, MetadataPlugin):
         self.base_url = JTABLE_BASE_URL
         # logger already initialized in base classes using subclass module name
 
+    def _fetch_page(self, url: str) -> requests.Response:
+        """获取页面，自动处理 Cloudflare Turnstile 保护。
+
+        先尝试普通 HTTP 请求（仅 1 次，不重试），
+        若返回 403 且检测到 Cloudflare 挑战页面，则回退到浏览器模式。
+        """
+        try:
+            resp = self.fetch(url, timeout=15, max_retry=1)
+            resp.raise_for_status()
+            return resp
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code == 403:
+                cf_markers = ["Just a moment", "cf-mitigated", "challenges.cloudflare.com"]
+                body = e.response.text[:2000]
+                if any(m in body for m in cf_markers):
+                    self.logger.info("检测到 Cloudflare Turnstile，使用浏览器获取")
+                    return self._fetch_with_browser(url)
+            raise
+
+    def _fetch_with_browser(self, url: str) -> requests.Response:
+        """使用 DrissionPage 浏览器绕过 Cloudflare 获取页面"""
+        from ..utils.http_utils import HttpUtils
+
+        return HttpUtils.fetch_with_browser(
+            url=url,
+            proxy_config=self.config.proxy,
+            logger=self.logger,
+            wait_for_content=["application/ld+json", "og:title", 'class="info"'],
+            reject_content=["Just a moment", "请稍候"],
+            max_wait=30,
+        )
+
     def initialize(self) -> bool:
         """初始化插件"""
         return True
@@ -112,7 +146,7 @@ class JTablePlugin(ExtractorPlugin, MetadataPlugin):
                 url = f"{self.base_url}/videos/{code}/"
                 self.logger.info(f"从代码构造URL: {url}")
 
-            response = self.fetch(url, timeout=30)
+            response = self._fetch_page(url)
             html = response.text
             if not html:
                 self.logger.error(f"获取页面内容失败: {url}")
@@ -203,7 +237,7 @@ class JTablePlugin(ExtractorPlugin, MetadataPlugin):
 
         try:
             # 获取网页内容
-            response = self.fetch(url)
+            response = self._fetch_page(url)
             html = response.text
             if not html:
                 self.logger.error(f"获取页面内容失败: {url}")

--- a/pavone/plugins/metadata/avbase_metadata.py
+++ b/pavone/plugins/metadata/avbase_metadata.py
@@ -22,7 +22,7 @@ PLUGIN_NAME = "AvBaseMetadata"
 PLUGIN_VERSION = "1.0.0"
 PLUGIN_DESCRIPTION = "提取 avbase.net 的视频元数据"
 PLUGIN_AUTHOR = "PAVOne"
-PLUGIN_PRIORITY = 50
+PLUGIN_PRIORITY = 70
 
 SUPPORTED_DOMAINS = ["avbase.net", "www.avbase.net"]
 SITE_NAME = "AVBASE"
@@ -84,7 +84,7 @@ class AvBaseMetadata(HtmlMetadataPlugin):
 
             api_url = MOVIE_API_TEMPLATE.format(build_id=build_id, movie_id=movie_id, movie_id_enc=movie_id)
             try:
-                resp = self.fetch(api_url, timeout=30)
+                resp = self.fetch(api_url, timeout=30, max_retry=1)
                 data = resp.json()
                 return self._parse_api(data, movie_id, page_url)
             except Exception:
@@ -115,7 +115,7 @@ class AvBaseMetadata(HtmlMetadataPlugin):
         if self._build_id:
             return self._build_id
         try:
-            resp = self.fetch("https://www.avbase.net/", timeout=15)
+            resp = self.fetch("https://www.avbase.net/", timeout=15, max_retry=1)
             soup = BeautifulSoup(resp.text, "lxml")
             # Next.js 将 buildId 注入到 __NEXT_DATA__ script 中
             script = soup.find("script", id="__NEXT_DATA__")
@@ -217,7 +217,7 @@ class AvBaseMetadata(HtmlMetadataPlugin):
         try:
             import json
 
-            resp = self.fetch(page_url, timeout=30)
+            resp = self.fetch(page_url, timeout=30, max_retry=1)
             soup = BeautifulSoup(resp.text, "lxml")
             script = soup.find("script", id="__NEXT_DATA__")
             if script and script.string:

--- a/pavone/plugins/metadata/caribbeancom_metadata.py
+++ b/pavone/plugins/metadata/caribbeancom_metadata.py
@@ -130,9 +130,17 @@ class CaribbeancomMetadata(HtmlMetadataPlugin):
         return None
 
     def _extract_movie_id_from_url(self, url: str, is_premium: bool = False) -> Optional[str]:
-        """从URL中提取番号"""
-        pattern = MOVIE_ID_PATTERN_PR if is_premium else MOVIE_ID_PATTERN
-        match = re.search(rf"/moviepages/({pattern})/", url)
+        """从URL中提取番号
+
+        caribbeancom.com 的 URL 中既可能出现 dash 也可能出现 underscore 格式的番号，
+        因此需要同时尝试两种模式。
+        """
+        # 优先尝试该域名对应的模式，再回退到另一种模式
+        primary = MOVIE_ID_PATTERN_PR if is_premium else MOVIE_ID_PATTERN
+        fallback = MOVIE_ID_PATTERN if is_premium else MOVIE_ID_PATTERN_PR
+        match = re.search(rf"/moviepages/({primary})/", url)
+        if not match:
+            match = re.search(rf"/moviepages/({fallback})/", url)
         return match.group(1) if match else None
 
     def _build_metadata_from_html(self, html: str, movie_id: str, is_premium: bool = False) -> Optional[MovieMetadata]:
@@ -159,14 +167,22 @@ class CaribbeancomMetadata(HtmlMetadataPlugin):
             rating = self._extract_rating(html)
             desc = self._extract_description(html)
 
-            # 从 HTML 画像ギャラリー区域提取图片链接
-            gallery_images = self._extract_gallery_images(html, movie_id, base_domain)
-            # l_l.jpg 作为 poster
-            poster = f"{base_domain}/moviepages/{movie_id}/images/l_l.jpg"
-            # 从背景图中选择高度最大的作为 cover
-            cover = self._select_tallest_image(gallery_images)
-            # 所有图片作为背景图（Jellyfin支持多张）
-            backdrops = gallery_images
+            # 解析页面中的 Movie JS 对象，判断是否为跨站影片（如 muramura、pacopacomama）
+            crossover = self._extract_crossover_image(html, movie_id)
+            if crossover:
+                # 跨站影片：图片托管在源站点的 assets/sample 目录，仅有单张图片
+                poster = crossover
+                cover = crossover
+                backdrops = [crossover]
+            else:
+                # 原生 caribbeancom：从 HTML 画像ギャラリー区域提取图片链接
+                gallery_images = self._extract_gallery_images(html, movie_id, base_domain)
+                # l_l.jpg 作为 poster
+                poster = f"{base_domain}/moviepages/{movie_id}/images/l_l.jpg"
+                # 从背景图中选择高度最大的作为 cover
+                cover = self._select_tallest_image(gallery_images)
+                # 所有图片作为背景图（Jellyfin支持多张）
+                backdrops = gallery_images
 
             display_title = title or "Unknown"
 
@@ -223,6 +239,38 @@ class CaribbeancomMetadata(HtmlMetadataPlugin):
         if best_url:
             self.logger.debug(f"选择 cover: {best_url} (高度 {max_height})")
         return best_url
+
+    def _extract_crossover_image(self, html: str, movie_id: str) -> Optional[str]:
+        """解析页面中的 Movie JS 对象，识别跨站影片并返回其图片 URL
+
+        部分番号（如 underscore 格式）实为 muramura / pacopacomama 等姊妹站点的影片，
+        通过 caribbeancom 分发。这些影片的图片不在 /moviepages/{id}/images/ 下，
+        而是托管在源站点的 /assets/sample/{id}/ 目录中。
+
+        页面中的 Movie 对象示例:
+            {"movie_id":"021416_352","movie_site":"mura","image_name":"str.jpg",
+             "site_name":"muramura.tv", ...}
+
+        返回图片 URL（如 https://www.muramura.tv/assets/sample/021416_352/str.jpg），
+        若不是跨站影片则返回 None。
+        """
+        import json
+
+        match = re.search(r"var\s+Movie\s*=\s*(\{.*?\})\s*;", html, re.S)
+        if not match:
+            return None
+        try:
+            movie = json.loads(match.group(1))
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+        site_name = movie.get("site_name")
+        # 仅当存在 site_name 且非 caribbeancom 本站时才视为跨站影片
+        if not site_name or "caribbeancom" in site_name:
+            return None
+
+        image_name = movie.get("image_name") or "str.jpg"
+        return f"https://www.{site_name}/assets/sample/{movie_id}/{image_name}"
 
     def _extract_gallery_images(
         self, html: str, movie_id: str, base_domain: str = "https://www.caribbeancom.com"

--- a/pavone/plugins/metadata/jav321_metadata.py
+++ b/pavone/plugins/metadata/jav321_metadata.py
@@ -11,6 +11,7 @@ import re
 from typing import List, Optional
 from urllib.parse import urlparse
 
+import requests
 from bs4 import BeautifulSoup, NavigableString
 
 from ...models import MovieMetadata
@@ -21,7 +22,7 @@ PLUGIN_NAME = "Jav321Metadata"
 PLUGIN_VERSION = "1.0.0"
 PLUGIN_DESCRIPTION = "提取 jav321.com 的视频元数据"
 PLUGIN_AUTHOR = "PAVOne"
-PLUGIN_PRIORITY = 50
+PLUGIN_PRIORITY = 70
 
 SUPPORTED_DOMAINS = ["jav321.com", "www.jav321.com"]
 SITE_NAME = "JAV321"
@@ -45,6 +46,9 @@ class Jav321Metadata(HtmlMetadataPlugin):
         if identifier.startswith("http://") or identifier.startswith("https://"):
             return self.can_handle_domain(identifier, SUPPORTED_DOMAINS)
         return bool(re.match(r"^[a-zA-Z]+-\d+$", identifier.strip()))
+
+    def _fetch_page(self, url: str) -> requests.Response:
+        return self.fetch(url, timeout=30, max_retry=1)
 
     def _resolve(self, identifier: str):
         if identifier.startswith("http://") or identifier.startswith("https://"):

--- a/pavone/plugins/metadata/supfc2_metadata.py
+++ b/pavone/plugins/metadata/supfc2_metadata.py
@@ -64,10 +64,10 @@ class SupFC2Metadata(FC2BaseMetadata):
         return bool(re.match(fc2_pattern, identifier_stripped))
 
     def _fetch_page(self, url: str) -> requests.Response:
-        """获取页面, verify_ssl=False: supfc2 站点 SSL 证书配置不标准，需跳过验证
+        """获取页面
 
         4xx (404 = 该番号不在 supfc2 库) 立即放弃重试，让上层 enrich 快速 fallback 到下一个 provider。"""
-        return self.fetch(url, timeout=30, verify_ssl=False, max_retry=2, should_retry=skip_retry_on_4xx)
+        return self.fetch(url, timeout=30, max_retry=2, should_retry=skip_retry_on_4xx)
 
     def _resolve(self, identifier: str) -> Tuple[Optional[str], Optional[str]]:
         """将 identifier 解析为 (fc2_id, page_url)"""

--- a/pavone/utils/file_operation_builder.py
+++ b/pavone/utils/file_operation_builder.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from ..config.logging_config import get_logger
-from ..models.constants import ItemType, OperationType
+from ..models.constants import ImageExtraKeys, ItemType, OperationType
 from .template_utils import TemplateUtils
 
 if TYPE_CHECKING:
@@ -145,11 +145,12 @@ class FileOperationBuilder:
             operation.append_child(poster_item)
             self.logger.debug(f"添加海报子操作: {metadata.poster}")
 
-        # 添加背景图（支持多张）
+        # 添加背景图（支持多张，Jellyfin 规范: backdrop.jpg, backdrop1.jpg, backdrop2.jpg ...）
         if config.download_cover:
             backdrop_urls = metadata.backdrops or ([metadata.backdrop] if metadata.backdrop else [])
-            for bd_url in backdrop_urls:
+            for idx, bd_url in enumerate(backdrop_urls):
                 backdrop_item = create_backdrop_item(url=bd_url, title=metadata.title or metadata.code)
+                backdrop_item.set_extra(ImageExtraKeys.BACKDROP_INDEX, idx)
                 operation.append_child(backdrop_item)
             if backdrop_urls:
                 self.logger.debug(f"添加背景图子操作: {len(backdrop_urls)} 张")


### PR DESCRIPTION
## 概述

本 PR 包含三组相关改进：organize 命令的重复番号处理、Jellyfin 多背景图命名规范，以及多个元数据插件的稳定性优化。

## 改动内容

### organize 命令 — 重复番号处理
- 整理前检测目标文件夹中是否已存在同番号视频
- 通过 ffprobe 探测本地视频质量，对比新文件与已有文件（分辨率、码率、大小）并给出建议
- 提供三种处理方式：跳过 / 覆盖 / 作为 Jellyfin Extra 移入 extras/ 子文件夹
- 提取共享常量 VIDEO_EXTENSIONS

### Jellyfin 多背景图命名
- 新增 BACKDROP_INDEX extra key
- 多张背景图按 Jellyfin 规范命名：backdrop.jpg、backdrop1.jpg、backdrop2.jpg …

### 元数据插件改进
- jtable：检测 Cloudflare Turnstile 保护，回退到浏览器模式获取页面
- caribbeancom：支持跨站影片（muramura / pacopacomama）图片解析，番号正则双向回退
- avbase / jav321：优先级提升至 70，限制重试（max_retry=1）
- supfc2：移除 verify_ssl=False
