### PR TITLE
fix(fc2ppv-db): persist browser challenge state

### DIFF
--- a/pavone/plugins/metadata/fc2ppv_db_metadata.py
+++ b/pavone/plugins/metadata/fc2ppv_db_metadata.py
@@ -16,6 +16,7 @@ ID 格式: 纯数字 FC2 PPV 编号
 
 import json
 import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
@@ -66,15 +67,15 @@ class Fc2ppvDbMetadata(FC2BaseMetadata):
 
     def can_extract(self, identifier: str) -> bool:
         if identifier.startswith("http://") or identifier.startswith("https://"):
-            return self.can_handle_domain(identifier, SUPPORTED_DOMAINS)
+            movie_id, _ = self._resolve(identifier)
+            return movie_id is not None and self.can_handle_domain(identifier, SUPPORTED_DOMAINS)
         return self._validate_fc2_identifier(identifier)
 
     def _fetch_page(self, url: str) -> requests.Response:
-        """使用浏览器获取页面：先过 Cloudflare，再以 age-verified cookie 绕过年龄确认页。
+        """使用持久化浏览器获取页面。
 
-        注意: 不能用 "年齢確認" 作为 reject 标记——该站点是 Next.js 应用，年龄确认
-        文案作为 i18n 数据常驻于真实页面 HTML 中。改用番号 ``FC2-PPV-{id}`` 作为
-        真实页已加载的正向标记（年龄确认页不含番号）。
+        持久化用户数据目录可复用 Cloudflare / 年龄确认 Cookie；``eager`` 加载模式可在 DOM 可用后
+        尽早返回，避免等待图片等资源完全加载。
         """
         movie_id = url.rstrip("/").split("/")[-1]
         return HttpUtils.fetch_with_browser(
@@ -82,11 +83,21 @@ class Fc2ppvDbMetadata(FC2BaseMetadata):
             proxy_config=self.config.proxy,
             logger=self.logger,
             wait_for_content=[f"FC2-PPV-{movie_id}"],
-            reject_content=["Just a moment", "請稍候", "请稍候"],
+            reject_content=[],
             max_wait=40,
             cookies=[AGE_COOKIE],
-            pre_visit_url=ROOT_URL,
+            browser_user_data_path=str(self._browser_user_data_path()),
+            browser_load_mode="eager",
         )
+
+    def _cache_base_dir(self) -> Path:
+        configured = self.config.download.cache_dir
+        if configured:
+            return Path(configured).expanduser() / "browser"
+        return Path.home() / ".cache" / "pavone" / "browser"
+
+    def _browser_user_data_path(self) -> Path:
+        return self._cache_base_dir() / "fc2ppv-db-profile"
 
     def _resolve(self, identifier: str) -> Tuple[Optional[str], Optional[str]]:
         if identifier.startswith("http://") or identifier.startswith("https://"):
@@ -94,8 +105,9 @@ class Fc2ppvDbMetadata(FC2BaseMetadata):
             parts = [p for p in parsed.path.split("/") if p]
             if "videos" in parts:
                 idx = parts.index("videos")
-                if idx + 1 < len(parts):
-                    return parts[idx + 1], identifier
+                if idx + 1 < len(parts) and parts[idx + 1].isdigit():
+                    movie_id = parts[idx + 1]
+                    return movie_id, MOVIE_URL_TEMPLATE.format(movie_id=movie_id)
             return None, None
         fc2_id = self._extract_fc2_id(identifier)
         if not fc2_id:

--- a/pavone/utils/http_utils.py
+++ b/pavone/utils/http_utils.py
@@ -1,6 +1,8 @@
+import socket
 import time
 from logging import Logger
-from typing import Callable, Dict, List, Optional, cast
+from pathlib import Path
+from typing import Callable, Dict, List, Literal, Optional, cast
 
 import requests
 
@@ -9,6 +11,13 @@ from pavone.config.configs import DownloadConfig, ProxyConfig
 # Cloudflare 挑战页（"Just a moment..." / Turnstile）的特征标记。
 # 仅用于判断浏览器是否已通过 Cloudflare，与业务层的 reject_content 解耦。
 _CLOUDFLARE_MARKERS = ["Just a moment", "challenges.cloudflare.com", "请稍候", "請稍候"]
+
+
+def _find_available_local_port() -> int:
+    """获取可供 Chromium 调试协议使用的本机端口。"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 def skip_retry_on_4xx(exc: requests.RequestException) -> bool:
@@ -163,6 +172,8 @@ class HttpUtils:
         max_wait: int = 30,
         cookies: Optional[List[Dict[str, str]]] = None,
         pre_visit_url: Optional[str] = None,
+        browser_user_data_path: Optional[str] = None,
+        browser_load_mode: Optional[Literal["normal", "eager", "none"]] = None,
     ) -> requests.Response:
         """使用真实浏览器（DrissionPage）获取网页内容，可绕过 Cloudflare Turnstile 等保护
 
@@ -185,6 +196,9 @@ class HttpUtils:
             pre_visit_url: 在设置 cookie 前先访问的 URL（通常是站点根域名），
                            某些站点需要先通过 Cloudflare 挑战才能在该域名下设置 cookie。
                            仅当提供 cookies 时生效
+            browser_user_data_path: 浏览器用户数据目录。提供后可复用 Cloudflare / 年龄确认 Cookie，
+                                    避免每次都从全新浏览器环境开始。
+            browser_load_mode: DrissionPage 页面加载策略（normal/eager/none），用于减少等待资源加载时间。
 
         Returns:
             requests.Response: 包含页面 HTML 的响应对象。
@@ -206,6 +220,8 @@ class HttpUtils:
                 max_wait=max_wait,
                 cookies=cookies,
                 pre_visit_url=pre_visit_url,
+                browser_user_data_path=browser_user_data_path,
+                browser_load_mode=browser_load_mode,
             )
         except Exception as e:
             if logger:
@@ -234,6 +250,8 @@ class HttpUtils:
         max_wait: int,
         cookies: Optional[List[Dict[str, str]]] = None,
         pre_visit_url: Optional[str] = None,
+        browser_user_data_path: Optional[str] = None,
+        browser_load_mode: Optional[Literal["normal", "eager", "none"]] = None,
     ) -> Optional[str]:
         """内部方法：使用 DrissionPage 浏览器获取页面 HTML
 
@@ -245,7 +263,15 @@ class HttpUtils:
         from DrissionPage import Chromium, ChromiumOptions
 
         options = ChromiumOptions()
-        options.auto_port()
+        if browser_user_data_path:
+            Path(browser_user_data_path).mkdir(parents=True, exist_ok=True)
+            options.set_user_data_path(browser_user_data_path)
+            # DrissionPage 的 auto_port() 会改用临时用户目录，导致持久化 Cookie 丢失。
+            options.set_local_port(_find_available_local_port())
+        else:
+            options.auto_port()
+        if browser_load_mode:
+            options.set_load_mode(browser_load_mode)
         # 不使用 headless 模式 - Cloudflare Turnstile 会检测无头浏览器
 
         # 应用代理配置

--- a/tests/metadata/test_fc2ppv_db.py
+++ b/tests/metadata/test_fc2ppv_db.py
@@ -23,6 +23,7 @@ class TestFc2ppvDbMetadata:
     def test_can_extract_url(self):
         assert self.extractor.can_extract("https://fc2ppv-db.com/ja/videos/4778286")
         assert self.extractor.can_extract("https://www.fc2ppv-db.com/ja/videos/4778286")
+        assert self.extractor.can_extract("https://fc2ppv-db.com/ja/videos/4778286?utm_source=test")
 
     def test_can_extract_movie_id(self):
         assert self.extractor.can_extract("4778286")
@@ -33,6 +34,8 @@ class TestFc2ppvDbMetadata:
         # 同为 FC2 数据库但不同域名，不应由本插件按 URL 处理
         assert not self.extractor.can_extract("https://fc2ppvdb.com/articles/4778286")
         assert not self.extractor.can_extract("https://example.com/ja/videos/4778286")
+        assert not self.extractor.can_extract("https://fc2ppv-db.com/ja")
+        assert not self.extractor.can_extract("https://fc2ppv-db.com/ja/videos/not-a-number")
         assert not self.extractor.can_extract("abc")
         assert not self.extractor.can_extract("")
 
@@ -40,6 +43,11 @@ class TestFc2ppvDbMetadata:
 
     def test_resolve_url(self):
         movie_id, url = self.extractor._resolve("https://fc2ppv-db.com/ja/videos/4778286")  # type: ignore[reportPrivateUsage]
+        assert movie_id == "4778286"
+        assert url == "https://fc2ppv-db.com/ja/videos/4778286"
+
+    def test_resolve_url_with_query(self):
+        movie_id, url = self.extractor._resolve("https://fc2ppv-db.com/ja/videos/4778286?utm_source=test")  # type: ignore[reportPrivateUsage]
         assert movie_id == "4778286"
         assert url == "https://fc2ppv-db.com/ja/videos/4778286"
 

--- a/tests/test_http_utils_retry.py
+++ b/tests/test_http_utils_retry.py
@@ -1,5 +1,6 @@
 """HttpUtils.fetch 重试与 should_retry 短路行为单测。"""
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -135,3 +136,58 @@ def test_custom_should_retry_callback(mock_get: MagicMock) -> None:
         )
 
     assert mock_get.call_count == 1
+
+
+def test_browser_persistent_profile_uses_explicit_port(tmp_path) -> None:
+    """持久化浏览器目录不能被 DrissionPage 的 auto_port 替换。"""
+    options = MagicMock()
+    browser = MagicMock()
+    browser.latest_tab.html = "<html>ready</html>"
+    drission_page = MagicMock()
+    drission_page.ChromiumOptions.return_value = options
+    drission_page.Chromium.return_value = browser
+
+    with (
+        patch.dict(sys.modules, {"DrissionPage": drission_page}),
+        patch("pavone.utils.http_utils._find_available_local_port", return_value=23456),
+    ):
+        html = HttpUtils._fetch_html_with_browser(  # type: ignore[reportPrivateUsage]
+            "https://example.com",
+            ProxyConfig(),
+            None,
+            ["ready"],
+            [],
+            1,
+            browser_user_data_path=str(tmp_path),
+        )
+
+    assert html == "<html>ready</html>"
+    options.set_user_data_path.assert_called_once_with(str(tmp_path))
+    options.set_local_port.assert_called_once_with(23456)
+    options.auto_port.assert_not_called()
+    browser.quit.assert_called_once()
+
+
+def test_browser_ephemeral_profile_keeps_auto_port() -> None:
+    """未指定持久化目录时继续使用 DrissionPage 的隔离临时目录。"""
+    options = MagicMock()
+    browser = MagicMock()
+    browser.latest_tab.html = "<html>ready</html>"
+    drission_page = MagicMock()
+    drission_page.ChromiumOptions.return_value = options
+    drission_page.Chromium.return_value = browser
+
+    with patch.dict(sys.modules, {"DrissionPage": drission_page}):
+        html = HttpUtils._fetch_html_with_browser(  # type: ignore[reportPrivateUsage]
+            "https://example.com",
+            ProxyConfig(),
+            None,
+            ["ready"],
+            [],
+            1,
+        )
+
+    assert html == "<html>ready</html>"
+    options.auto_port.assert_called_once_with()
+    options.set_local_port.assert_not_called()
+    browser.quit.assert_called_once()


### PR DESCRIPTION
## Summary
- persist the FC2PPV-DB browser profile so Cloudflare and age-verification cookies survive across requests
- preserve the configured user-data directory by using an explicit available debugging port instead of DrissionPage auto-port mode
- normalize and validate FC2PPV-DB video URLs before extraction

## Tests
- uv run pytest tests/test_http_utils_retry.py tests/metadata/test_fc2ppv_db.py -q