### PR TITLE
fix(metadata): improve plugin diagnostics and monitoring

### DIFF
--- a/.github/workflows/daily-metadata-test.yml
+++ b/.github/workflows/daily-metadata-test.yml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
+  contents: read
   discussions: write
 
 jobs:
@@ -29,29 +31,61 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Download previous successful results
+        id: previous
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREVIOUS_RUN_ID=$(gh api \
+            --method GET \
+            "repos/${{ github.repository }}/actions/workflows/daily-metadata-test.yml/runs" \
+            -f status=success \
+            -f branch="${{ github.ref_name }}" \
+            -f per_page=1 \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -z "$PREVIOUS_RUN_ID" ]; then
+            echo "No previous successful run found."
+            exit 0
+          fi
+
+          DOWNLOAD_DIR="$RUNNER_TEMP/metadata-previous"
+          gh run download "$PREVIOUS_RUN_ID" --repo "${{ github.repository }}" --pattern 'metadata-test-*' --dir "$DOWNLOAD_DIR"
+          PREVIOUS_RESULTS=$(find "$DOWNLOAD_DIR" -name metadata_test_results.json -print -quit)
+          if [ -n "$PREVIOUS_RESULTS" ]; then
+            echo "path=$PREVIOUS_RESULTS" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run metadata plugin tests
         id: test
+        env:
+          PREVIOUS_RESULTS: ${{ steps.previous.outputs.path }}
         run: |
-          uv run python scripts/test_metadata_plugins.py \
-            --output-dir /tmp/metadata-test \
-            --format both
+          ARGS=(--output-dir "$RUNNER_TEMP/metadata-test" --format both)
+          if [ -n "$PREVIOUS_RESULTS" ] && [ -f "$PREVIOUS_RESULTS" ]; then
+            ARGS+=(--previous-results "$PREVIOUS_RESULTS")
+          fi
+          xvfb-run --auto-servernum uv run python scripts/test_metadata_plugins.py "${ARGS[@]}"
         continue-on-error: true
 
       - name: Read test results
         id: results
         run: |
-          if [ -f /tmp/metadata-test/metadata_test_results.json ]; then
-            TOTAL=$(jq '.results | length' /tmp/metadata-test/metadata_test_results.json)
-            OK=$(jq '[.results[] | select(.status == "OK")] | length' /tmp/metadata-test/metadata_test_results.json)
-            FAIL=$(jq '[.results[] | select(.status == "FAIL")] | length' /tmp/metadata-test/metadata_test_results.json)
-            ERROR=$(jq '[.results[] | select(.status == "ERROR")] | length' /tmp/metadata-test/metadata_test_results.json)
-            AVG_SCORE=$(jq '[.results[] | select(.status == "OK") | .score] | if length > 0 then (add / length * 10 | round / 10) else 0 end' /tmp/metadata-test/metadata_test_results.json)
-            ELAPSED=$(jq '.total_time_s' /tmp/metadata-test/metadata_test_results.json)
-            VERSION=$(jq -r '.version' /tmp/metadata-test/metadata_test_results.json)
+          RESULTS="$RUNNER_TEMP/metadata-test/metadata_test_results.json"
+          if [ -f "$RESULTS" ]; then
+            TOTAL=$(jq '.results | length' "$RESULTS")
+            OK=$(jq '[.results[] | select(.status == "OK")] | length' "$RESULTS")
+            DEGRADED=$(jq '[.results[] | select(.status == "DEGRADED")] | length' "$RESULTS")
+            FAIL=$(jq '[.results[] | select(.status == "FAIL")] | length' "$RESULTS")
+            ERROR=$(jq '[.results[] | select(.status == "ERROR")] | length' "$RESULTS")
+            AVG_SCORE=$(jq '[.results[] | select(.status == "OK") | .score] | if length > 0 then (add / length * 10 | round / 10) else 0 end' "$RESULTS")
+            ELAPSED=$(jq '.total_time_s' "$RESULTS")
+            VERSION=$(jq -r '.version' "$RESULTS")
             DATE=$(date -u +%Y-%m-%d)
 
             echo "total=$TOTAL" >> $GITHUB_OUTPUT
             echo "ok=$OK" >> $GITHUB_OUTPUT
+            echo "degraded=$DEGRADED" >> $GITHUB_OUTPUT
             echo "fail=$FAIL" >> $GITHUB_OUTPUT
             echo "error=$ERROR" >> $GITHUB_OUTPUT
             echo "avg_score=$AVG_SCORE" >> $GITHUB_OUTPUT
@@ -72,7 +106,7 @@ jobs:
           CATEGORY_ID=$(gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { discussionCategories(first: 10) { nodes { id slug } } } }' --jq '.data.repository.discussionCategories.nodes[] | select(.slug == "general") | .id')
 
           # Create discussion with test report
-          BODY=$(cat /tmp/metadata-test/metadata_test_report.md)
+          BODY=$(cat "$RUNNER_TEMP/metadata-test/metadata_test_report.md")
           gh api graphql \
             -F repositoryId="$REPO_NODE_ID" \
             -F categoryId="$CATEGORY_ID" \
@@ -89,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: metadata-test-${{ steps.results.outputs.date || 'unknown' }}
-          path: /tmp/metadata-test/
+          path: ${{ runner.temp }}/metadata-test/
           retention-days: 30
 
       - name: Summary
@@ -102,6 +136,7 @@ jobs:
           echo "| 版本 | v${{ steps.results.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 总插件数 | ${{ steps.results.outputs.total }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ✅ 成功 | ${{ steps.results.outputs.ok }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ⚠️ 质量降级 | ${{ steps.results.outputs.degraded }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ❌ 失败 | ${{ steps.results.outputs.fail }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 💥 异常 | ${{ steps.results.outputs.error }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 平均评分 | ${{ steps.results.outputs.avg_score }}/100 |" >> $GITHUB_STEP_SUMMARY

--- a/pavone/plugins/metadata/avbase_metadata.py
+++ b/pavone/plugins/metadata/avbase_metadata.py
@@ -71,12 +71,15 @@ class AvBaseMetadata(HtmlMetadataPlugin):
 
     def extract_metadata(self, identifier: str) -> Optional[MovieMetadata]:
         """API 优先, 回退到 HTML __NEXT_DATA__ 解析"""
+        self._reset_diagnostic()
         try:
             movie_id, page_url = self._resolve(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
 
+            self._set_diagnostic_stage("fetch")
             build_id = self._get_build_id()
             if not build_id:
                 # Fallback: HTML 直接解析
@@ -85,16 +88,25 @@ class AvBaseMetadata(HtmlMetadataPlugin):
             api_url = MOVIE_API_TEMPLATE.format(build_id=build_id, movie_id=movie_id, movie_id_enc=movie_id)
             try:
                 resp = self.fetch(api_url, timeout=30, max_retry=1)
+                self._record_response(resp)
+                self._set_diagnostic_stage("parse")
                 data = resp.json()
-                return self._parse_api(data, movie_id, page_url)
+                metadata = self._parse_api(data, movie_id, page_url)
+                if metadata is None:
+                    self._record_failure("API 解析器返回空结果")
+                else:
+                    self._set_diagnostic_stage("complete")
+                return metadata
             except Exception:
                 # API 失败时回退到 HTML 解析
                 return self._extract_from_html(movie_id, page_url)
 
         except requests.RequestException as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTTP 请求失败: {e}")
             return None
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 
@@ -217,14 +229,23 @@ class AvBaseMetadata(HtmlMetadataPlugin):
         try:
             import json
 
+            self._set_diagnostic_stage("fetch")
             resp = self.fetch(page_url, timeout=30, max_retry=1)
+            self._record_response(resp)
             soup = BeautifulSoup(resp.text, "lxml")
             script = soup.find("script", id="__NEXT_DATA__")
             if script and script.string:
+                self._set_diagnostic_stage("parse")
                 data = json.loads(script.string)
                 # __NEXT_DATA__ 中 pageProps 在 props 下: {"props": {"pageProps": {...}}}
                 props = data.get("props") or {}
-                return self._parse_api(props, movie_id, page_url)
+                metadata = self._parse_api(props, movie_id, page_url)
+                if metadata is not None:
+                    self._set_diagnostic_stage("complete")
+                    return metadata
+            self._set_diagnostic_stage("parse")
+            self._record_failure("HTML 回退解析器返回空结果")
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTML 解析回退失败: {e}")
         return None

--- a/pavone/plugins/metadata/base.py
+++ b/pavone/plugins/metadata/base.py
@@ -5,7 +5,8 @@
 import json
 import re
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
 import requests
@@ -13,6 +14,17 @@ from bs4 import BeautifulSoup
 
 from ...models import BaseMetadata
 from ..base import BasePlugin
+
+
+@dataclass
+class MetadataDiagnostic:
+    """最近一次元数据提取的诊断上下文。"""
+
+    stage: str = "idle"
+    error: Optional[str] = None
+    exception_type: Optional[str] = None
+    http_status: Optional[int] = None
+    final_url: Optional[str] = None
 
 
 class MetadataPlugin(BasePlugin):
@@ -37,6 +49,29 @@ class MetadataPlugin(BasePlugin):
             author=author,
             priority=priority,
         )
+        self._last_diagnostic = MetadataDiagnostic()
+
+    def _reset_diagnostic(self) -> None:
+        self._last_diagnostic = MetadataDiagnostic(stage="resolve")
+
+    def _set_diagnostic_stage(self, stage: str) -> None:
+        self._last_diagnostic.stage = stage
+
+    def _record_response(self, response: requests.Response) -> None:
+        self._last_diagnostic.http_status = response.status_code
+        self._last_diagnostic.final_url = response.url
+
+    def _record_failure(self, error: str, exception: Optional[Exception] = None) -> None:
+        self._last_diagnostic.error = error
+        if exception is not None:
+            self._last_diagnostic.exception_type = type(exception).__name__
+            response = getattr(exception, "response", None)
+            if isinstance(response, requests.Response):
+                self._record_response(response)
+
+    def get_last_diagnostic(self) -> Dict[str, Any]:
+        """返回最近一次提取的诊断快照。"""
+        return asdict(self._last_diagnostic)
 
     def initialize(self) -> bool:
         """初始化插件"""
@@ -111,18 +146,30 @@ class HtmlMetadataPlugin(MetadataPlugin):
 
     def extract_metadata(self, identifier: str) -> Optional[BaseMetadata]:
         """模板方法: resolve → fetch → parse，统一错误处理。"""
+        self._reset_diagnostic()
         try:
             movie_id, page_url = self._resolve(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
+            self._set_diagnostic_stage("fetch")
             resp = self._fetch_page(page_url)
+            self._record_response(resp)
             soup = BeautifulSoup(resp.text, "lxml")
-            return self._parse(soup, movie_id, page_url)
+            self._set_diagnostic_stage("parse")
+            metadata = self._parse(soup, movie_id, page_url)
+            if metadata is None:
+                self._record_failure("解析器返回空结果")
+            else:
+                self._set_diagnostic_stage("complete")
+            return metadata
         except requests.RequestException as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTTP 请求失败: {e}")
             return None
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 
@@ -226,19 +273,31 @@ class ApiMetadataPlugin(MetadataPlugin):
 
     def extract_metadata(self, identifier: str) -> Optional[BaseMetadata]:
         """模板方法: resolve → build_api_url → fetch_api → json → parse。"""
+        self._reset_diagnostic()
         try:
             movie_id, page_url = self._resolve(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
             api_url = self._build_api_url(movie_id)
+            self._set_diagnostic_stage("fetch")
             resp = self._fetch_api(api_url)
+            self._record_response(resp)
+            self._set_diagnostic_stage("parse")
             data = resp.json()
-            return self._parse(data, movie_id, page_url)
+            metadata = self._parse(data, movie_id, page_url)
+            if metadata is None:
+                self._record_failure("解析器返回空结果")
+            else:
+                self._set_diagnostic_stage("complete")
+            return metadata
         except requests.RequestException as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTTP 请求失败: {e}")
             return None
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 
@@ -271,19 +330,31 @@ class JsonLdMetadataPlugin(HtmlMetadataPlugin):
 
     def extract_metadata(self, identifier: str) -> Optional[BaseMetadata]:
         """模板方法: resolve → fetch → BS4 → extract_jsonld → parse_with_jsonld。"""
+        self._reset_diagnostic()
         try:
             movie_id, page_url = self._resolve(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
+            self._set_diagnostic_stage("fetch")
             resp = self._fetch_page(page_url)
+            self._record_response(resp)
             soup = BeautifulSoup(resp.text, "lxml")
             jsonld_data = self._extract_jsonld(soup)
-            return self._parse_with_jsonld(soup, jsonld_data, movie_id, page_url)
+            self._set_diagnostic_stage("parse")
+            metadata = self._parse_with_jsonld(soup, jsonld_data, movie_id, page_url)
+            if metadata is None:
+                self._record_failure("JSON-LD 解析器返回空结果")
+            else:
+                self._set_diagnostic_stage("complete")
+            return metadata
         except requests.RequestException as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTTP 请求失败: {e}")
             return None
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 
@@ -292,10 +363,12 @@ class JsonLdMetadataPlugin(HtmlMetadataPlugin):
         for script in soup.find_all("script", type="application/ld+json"):
             try:
                 text = (script.string or "").replace("\n", "")
-                data = json.loads(text)
+                data: object = json.loads(text)
                 if isinstance(data, list):
-                    data = data[0]
-                return data
+                    items = cast(List[object], data)
+                    data = items[0] if items else None
+                if isinstance(data, dict):
+                    return cast(Dict[str, Any], data)
             except Exception:
                 continue
         return None

--- a/pavone/plugins/metadata/fanza_metadata.py
+++ b/pavone/plugins/metadata/fanza_metadata.py
@@ -135,34 +135,49 @@ class FanzaMetadata(HtmlMetadataPlugin):
 
     def extract_metadata(self, identifier: str) -> Optional[MovieMetadata]:
         """多通道解析: GraphQL API → __NEXT_DATA__ → HTML + JSON-LD"""
+        self._reset_diagnostic()
         try:
             movie_id, page_url, floor = self._resolve_with_floor(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
 
             # 1. GraphQL API (video.dmm.co.jp 所有内容类型)
+            self._set_diagnostic_stage("fetch")
             result = self._try_graphql(movie_id, floor, page_url)
             if result:
+                self._set_diagnostic_stage("complete")
                 return result
 
             # 2. HTML 回退 (传统 www.dmm.co.jp 页面)
+            self._set_diagnostic_stage("fetch")
             resp = self._fetch_page(page_url)
+            self._record_response(resp)
             soup = BeautifulSoup(resp.text, "lxml")
+            self._set_diagnostic_stage("parse")
 
             # 2a. __NEXT_DATA__ (旧版 video.dmm.co.jp 页面)
             next_data = soup.find("script", id="__NEXT_DATA__")
             if next_data and next_data.string:
                 result = self._parse_next_data(next_data.string, movie_id, page_url)
                 if result:
+                    self._set_diagnostic_stage("complete")
                     return result
 
             # 2b. 传统 HTML 页面
-            return self._parse_html(soup, movie_id, page_url)
+            result = self._parse_html(soup, movie_id, page_url)
+            if result is None:
+                self._record_failure("解析器返回空结果")
+            else:
+                self._set_diagnostic_stage("complete")
+            return result
         except requests.RequestException as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"HTTP 请求失败: {e}")
             return None
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 
@@ -246,7 +261,9 @@ class FanzaMetadata(HtmlMetadataPlugin):
             proxies=proxies,
             timeout=30,
         )
+        self._record_response(resp)
         resp.raise_for_status()
+        self._set_diagnostic_stage("parse")
         body = resp.json()
         ppv = (body.get("data") or {}).get("ppvContent")
         if not ppv or not ppv.get("title"):

--- a/pavone/plugins/metadata/gcolle_metadata.py
+++ b/pavone/plugins/metadata/gcolle_metadata.py
@@ -8,7 +8,7 @@ ID 格式: 纯数字
 """
 
 import re
-from typing import List, Optional
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -65,17 +65,28 @@ class GcolleMetadata(HtmlMetadataPlugin):
     def _fetch_page(self, url: str) -> requests.Response:
         """覆写以处理年龄认证页面"""
         resp = self.fetch(url, timeout=30)
-        # 检查是否命中年龄认证页面（内容过短且包含 age_check 链接）
-        if len(resp.text) < 2000 and "age_check" in resp.text:
-            soup = BeautifulSoup(resp.text, "lxml")
-            for a in soup.find_all("a"):
-                if a.get_text(strip=True) == "はい" and "age_check" in (a.get("href") or ""):
-                    session = requests.Session()
-                    session.cookies.update(dict(resp.cookies))
-                    session.headers.update({"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"})
-                    resp = session.get(str(a["href"]), timeout=30)
-                    resp.raise_for_status()
-                    break
+        soup = BeautifulSoup(resp.text, "lxml")
+        confirm = next(
+            (
+                a
+                for a in soup.select("a[href*='age_check']")
+                if a.get_text(strip=True) == "はい" and isinstance(a.get("href"), str)
+            ),
+            None,
+        )
+        if confirm:
+            cookies: Dict[str, str] = {}
+            for response in [*resp.history, resp]:
+                cookies.update(response.cookies.get_dict())
+            resp = self.fetch(
+                str(confirm["href"]),
+                timeout=30,
+                cookies=cookies,
+                headers={
+                    "Referer": resp.url,
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+                },
+            )
         return resp
 
     def _parse(self, soup: BeautifulSoup, movie_id: str, page_url: str) -> Optional[MovieMetadata]:
@@ -92,11 +103,13 @@ class GcolleMetadata(HtmlMetadataPlugin):
         t_el = soup.select_one("#cart_quantity h1")
         if t_el:
             title = t_el.get_text(strip=True)
+        if not title:
+            self.logger.error(f"页面不包含商品标题，可能仍停留在年龄认证页: {page_url}")
+            return None
 
         # Summary/plot
-        p_el = soup.select_one("#cart_quantity p")
-        if p_el:
-            plot = p_el.get_text(strip=True)
+        paragraphs = [p.get_text(" ", strip=True) for p in soup.select("#cart_quantity p")]
+        plot = max((text for text in paragraphs if text), key=len, default=None)
 
         # Genres
         for a in soup.select("#cart_quantity a"):

--- a/pavone/plugins/metadata/supfc2_metadata.py
+++ b/pavone/plugins/metadata/supfc2_metadata.py
@@ -89,16 +89,27 @@ class SupFC2Metadata(FC2BaseMetadata):
         lxml 解析器会重组 <head>/<body> 等文档结构标签，导致 str(soup) 与原始 HTML
         不一致，正则在 str(soup) 上匹配 og:image 等 meta 标签会失败。
         """
+        self._reset_diagnostic()
         try:
             movie_id, page_url = self._resolve(identifier)
             if not movie_id or not page_url:
+                self._record_failure(f"无法解析 identifier: {identifier}")
                 self.logger.error(f"无法解析 identifier: {identifier}")
                 return None
+            self._set_diagnostic_stage("fetch")
             resp = self._fetch_page(page_url)
+            self._record_response(resp)
             self._raw_html = resp.text
             soup = BeautifulSoup(resp.text, "lxml")
-            return self._parse(soup, movie_id, page_url)
+            self._set_diagnostic_stage("parse")
+            metadata = self._parse(soup, movie_id, page_url)
+            if metadata is None:
+                self._record_failure("解析器返回空结果")
+            else:
+                self._set_diagnostic_stage("complete")
+            return metadata
         except Exception as e:
+            self._record_failure(str(e), e)
             self.logger.error(f"提取元数据失败: {e}", exc_info=True)
             return None
 

--- a/pavone/utils/http_utils.py
+++ b/pavone/utils/http_utils.py
@@ -138,7 +138,9 @@ class HttpUtils:
         if no_exceptions:
             # 如果设置了不抛出异常，返回一个空响应对象
             return last_response or requests.Response()
-        raise requests.RequestException(f"获取网页失败 {url}: {last_exception}")
+        if last_exception is not None:
+            raise last_exception
+        raise requests.RequestException(f"获取网页失败 {url}")
 
     @staticmethod
     def get_proxies(proxy_config: ProxyConfig) -> Optional[Dict[str, str]]:

--- a/scripts/test_metadata_plugins.py
+++ b/scripts/test_metadata_plugins.py
@@ -13,76 +13,151 @@ PAVOne 元数据插件全量集成测试
 import argparse
 import json
 import logging
+import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 # Ensure pavone is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-# fmt: off
 TEST_CASES: List[Tuple[str, str, str]] = [
     # (plugin_class_name, base_class, test_identifier)
     # === HtmlMetadataPlugin ===
-    ("DahliaMetadata",              "Html",     "https://dahlia-av.jp/works/dldss339/"),
-    ("FalenoMetadata",              "Html",     "https://faleno.jp/top/works/fns196/"),
-    ("MyWifeMetadata",              "Html",     "https://mywife.cc/teigaku/model/no/1894"),
-    ("MgstageMetadata",             "Html",     "https://www.mgstage.com/product/product_detail/200GANA-3191/"),
-    ("GetchuMetadata",              "Html",     "https://dl.getchu.com/i/item4043542"),
-    ("MadouquMetadata",             "Html",     "https://madouqu.com/video/mm-103/"),
-    ("DugaMetadata",                "Html",     "https://duga.jp/ppv/mousouzoku2-1275/"),
-    ("Jav321Metadata",              "Html",     "https://www.jav321.com/video/snos00115"),
-    ("JavbusMetadata",              "Html",     "https://www.javbus.com/ja/SSIS-001"),
-    ("TokyoHotMetadata",            "Html",     "https://my.tokyo-hot.com/product/20032/?lang=ja"),
-    ("HeydougaMetadata",            "Html",     "https://www.heydouga.com/moviepages/4030/2826/index.html"),
-    ("AvEntertainmentsMetadata",    "Html",     "https://www.aventertainments.com/dvd/detail?pro=95843&lang=2&culture=ja-JP&cat=29"),
-    ("GcolleMetadata",              "Html",     "https://gcolle.net/product_info.php/products_id/1001529"),
-    ("JavfreeMetadata",             "Html",     "https://javfree.me/384459/venx-281"),
-    ("PcolleMetadata",              "Html",     "https://www.pcolle.com/product/detail/?product_id=27567069de31e4f23ce"),
-    ("CaribbeancomMetadata",        "Html",     "https://www.caribbeancom.com/moviepages/033026-001/index.html"),
-    ("FanzaMetadata",               "Html",     "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=midv00047/"),
-    ("AvBaseMetadata",              "Html",     "https://www.avbase.net/works/SSIS-001"),
+    ("DahliaMetadata", "Html", "https://dahlia-av.jp/works/dldss339/"),
+    ("FalenoMetadata", "Html", "https://faleno.jp/top/works/fns196/"),
+    ("MyWifeMetadata", "Html", "https://mywife.cc/teigaku/model/no/1894"),
+    ("MgstageMetadata", "Html", "https://www.mgstage.com/product/product_detail/200GANA-3191/"),
+    ("GetchuMetadata", "Html", "https://dl.getchu.com/i/item4043542"),
+    ("MadouquMetadata", "Html", "https://madouqu.com/video/mm-103/"),
+    ("DugaMetadata", "Html", "https://duga.jp/ppv/mousouzoku2-1275/"),
+    ("Jav321Metadata", "Html", "https://www.jav321.com/video/snos00115"),
+    ("JavbusMetadata", "Html", "https://www.javbus.com/ja/SSIS-001"),
+    ("TokyoHotMetadata", "Html", "https://my.tokyo-hot.com/product/n0697/?lang=ja"),
+    ("HeydougaMetadata", "Html", "https://www.heydouga.com/moviepages/4386/088/index.html"),
+    ("AvEntertainmentsMetadata", "Html", "https://www.aventertainments.com/dvd/detail?pro=95843&lang=2&culture=ja-JP&cat=29"),
+    ("GcolleMetadata", "Html", "https://gcolle.net/product_info.php/products_id/847256"),
+    ("JavfreeMetadata", "Html", "https://javfree.me/384459/venx-281"),
+    ("PcolleMetadata", "Html", "https://www.pcolle.com/product/detail/?product_id=27567069de31e4f23ce"),
+    ("CaribbeancomMetadata", "Html", "https://www.caribbeancom.com/moviepages/033026-001/index.html"),
+    ("FanzaMetadata", "Html", "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=midv00047/"),
+    ("AvBaseMetadata", "Html", "https://www.avbase.net/works/SSIS-001"),
     # === ApiMetadataPlugin ===
-    ("MuramuraMetadata",            "Api",      "https://www.muramura.tv/movies/040826_1229/"),
-    ("PacopacomamaMetadata",        "Api",      "https://www.pacopacomama.com/movies/040726_100/"),
-    ("OnePondoMetadata",            "Api",      "https://www.1pondo.tv/movies/032417_504/"),
-    ("TenMusumeMetadata",           "Api",      "https://www.10musume.com/movies/040726_01/"),
+    ("MuramuraMetadata", "Api", "https://www.muramura.tv/movies/040826_1229/"),
+    ("PacopacomamaMetadata", "Api", "https://www.pacopacomama.com/movies/040726_100/"),
+    ("OnePondoMetadata", "Api", "https://www.1pondo.tv/movies/032417_504/"),
+    ("TenMusumeMetadata", "Api", "https://www.10musume.com/movies/040726_01/"),
     # === JsonLdMetadataPlugin ===
-    ("C0930Metadata",               "JsonLd",   "https://www.c0930.com/moviepages/ki220913/index.html"),
-    ("H0930Metadata",               "JsonLd",   "https://www.h0930.com/moviepages/ori1234/index.html"),
-    ("H4610Metadata",               "JsonLd",   "https://www.h4610.com/moviepages/gol123/index.html"),
-    ("Fc2HubMetadata",              "JsonLd",   "https://javten.com/video/2045529/id4848768/%E3%80%90%E3%83%90%E3%83%AC%E3%83%B3%E3%82%BF%E3%82%A4%E3%83%B3%E3%82%BB%E3%83%BC%E3%83%AB%E2%91%A1%E3%80%91"),
-    ("HeyzoMetadata",               "JsonLd",   "https://www.heyzo.com/moviepages/3456/index.html"),
+    ("C0930Metadata", "JsonLd", "https://www.c0930.com/moviepages/ki220913/index.html"),
+    ("H0930Metadata", "JsonLd", "https://www.h0930.com/moviepages/ori1234/index.html"),
+    ("H4610Metadata", "JsonLd", "https://www.h4610.com/moviepages/gol123/index.html"),
+    (
+        "Fc2HubMetadata",
+        "JsonLd",
+        "https://javten.com/video/2045529/id4848768/%E3%80%90%E3%83%90%E3%83%AC%E3%83%B3%E3%82%BF%E3%82%A4%E3%83%B3%E3%82%BB%E3%83%BC%E3%83%AB%E2%91%A1%E3%80%91",
+    ),
+    ("HeyzoMetadata", "JsonLd", "https://www.heyzo.com/moviepages/3456/index.html"),
     # === FC2 Family (Html via FC2BaseMetadata) ===
-    ("Fc2PpvdbMetadata",            "Html/FC2", "https://fc2ppvdb.com/articles/1482027"),
-    ("SupFC2Metadata",              "Html/FC2", "FC2-PPV-1482027"),
-    ("PPVDataBankMetadata",         "Html/FC2", "FC2-2941579"),
+    ("Fc2PpvdbMetadata", "Html/FC2", "https://fc2ppvdb.com/articles/1482027"),
+    ("Fc2ppvDbMetadata", "Html/FC2", "https://fc2ppv-db.com/ja/videos/4778286"),
+    ("SupFC2Metadata", "Html/FC2", "FC2-PPV-1482027"),
+    ("PPVDataBankMetadata", "Html/FC2", "FC2-2941579"),
 ]
-# fmt: on
 
-FIELD_WEIGHTS: Dict[str, int] = {}
-try:
-    from pavone.models.constants import METADATA_SCORE_WEIGHTS
 
-    # 从统一权重生成插件字段权重（维度名与 MovieMetadata 字段名一致）
-    FIELD_WEIGHTS = dict(METADATA_SCORE_WEIGHTS)
-except ImportError:
-    # 回退: 如果无法导入则使用内联定义（与 constants.METADATA_SCORE_WEIGHTS 保持一致）
-    FIELD_WEIGHTS = {
-        "title": 1,
-        "actors": 13,
-        "cover": 11,
-        "plot": 16,
-        "premiered": 9,
-        "genres": 9,
-        "tags": 11,
-        "studio": 11,
-        "runtime": 1,
-        "rating": 5,
-        "director": 5,
-        "thumbnail": 8,
-    }
+def _load_field_weights() -> Dict[str, int]:
+    try:
+        from pavone.models.constants import METADATA_SCORE_WEIGHTS
+
+        return dict(METADATA_SCORE_WEIGHTS)
+    except ImportError:
+        return {
+            "title": 1,
+            "actors": 13,
+            "cover": 11,
+            "plot": 16,
+            "premiered": 9,
+            "genres": 9,
+            "tags": 11,
+            "studio": 11,
+            "runtime": 1,
+            "rating": 5,
+            "director": 5,
+            "thumbnail": 8,
+        }
+
+
+FIELD_WEIGHTS = _load_field_weights()
+
+QUALITY_GATES: Dict[str, Dict[str, Any]] = {
+    "TokyoHotMetadata": {
+        "min_score": 70,
+        "required_fields": ("title", "cover", "premiered", "studio"),
+    },
+    "JavfreeMetadata": {
+        "min_score": 25,
+        "required_fields": ("title", "cover", "premiered", "director"),
+    },
+    "PPVDataBankMetadata": {
+        "min_score": 30,
+        "required_fields": ("title", "cover", "premiered", "studio"),
+    },
+    "MyWifeMetadata": {
+        "min_score": 45,
+        "required_fields": ("title", "cover", "studio"),
+    },
+    "PcolleMetadata": {
+        "min_score": 50,
+        "required_fields": ("title", "cover", "premiered", "studio", "plot"),
+    },
+}
+SIGNIFICANT_SCORE_DROP = 10
+TRACKING_ISSUE_URL = "https://github.com/imbatony/pavone/issues/126"
+STATUS_SEVERITY = {
+    "OK": 0,
+    "DEGRADED": 1,
+    "SKIP": 2,
+    "FAIL": 3,
+    "NOT_FOUND": 3,
+    "ERROR": 4,
+}
+
+
+def classify_failure(diagnostic: Dict[str, Any]) -> str:
+    """将提取失败归类为可操作的故障类型。"""
+    stage = str(diagnostic.get("stage") or "")
+    error = str(diagnostic.get("error") or "").casefold()
+    status = diagnostic.get("http_status")
+    if not isinstance(status, int):
+        status_match = re.search(r"\b([45]\d{2})\b", error)
+        status = int(status_match.group(1)) if status_match else None
+
+    if status in (401, 403, 429) or any(marker in error for marker in ("cloudflare", "forbidden", "access denied")):
+        return "BLOCKED"
+    if status in (404, 410) or stage == "resolve":
+        return "STALE_CASE"
+    if (
+        isinstance(status, int)
+        and status >= 500
+        or any(
+            marker in error
+            for marker in (
+                "timeout",
+                "timed out",
+                "connection",
+                "dns",
+                "name resolution",
+                "network",
+                "proxy",
+                "ssl",
+            )
+        )
+    ):
+        return "NETWORK"
+    if stage == "parse":
+        return "PARSE"
+    return "EMPTY_RESULT"
 
 
 def score_metadata(metadata_obj: Any) -> Tuple[int, Dict[str, bool]]:
@@ -94,7 +169,7 @@ def score_metadata(metadata_obj: Any) -> Tuple[int, Dict[str, bool]]:
     for field, weight in FIELD_WEIGHTS.items():
         val = getattr(metadata_obj, field, None)
         has_value = val is not None and val != "" and val != [] and val != 0
-        if isinstance(val, list) and len(val) == 0:
+        if isinstance(val, list) and not val:
             has_value = False
         fields[field] = has_value
         if has_value:
@@ -102,7 +177,151 @@ def score_metadata(metadata_obj: Any) -> Tuple[int, Dict[str, bool]]:
     return score, fields
 
 
-def run_tests() -> List[Dict[str, Any]]:
+def _has_meaningful_title(metadata_obj: Any) -> bool:
+    """标题必须包含代码以外的有效内容。"""
+    title = str(getattr(metadata_obj, "title", "") or "").strip()
+    code = str(getattr(metadata_obj, "code", "") or "").strip()
+    if not title:
+        return False
+
+    def normalize(value: str) -> str:
+        return re.sub(r"[\W_]+", "", value.casefold())
+
+    normalized_code = normalize(code)
+    if not normalized_code:
+        return True
+    return bool(normalize(title).replace(normalized_code, ""))
+
+
+def evaluate_quality_gate(plugin_name: str, metadata_obj: Any, score: int, fields: Dict[str, bool]) -> Dict[str, Any]:
+    """评估插件的最低分和关键字段门禁。"""
+    gate = QUALITY_GATES.get(plugin_name)
+    if gate is None:
+        return {}
+
+    required_fields = cast(Tuple[str, ...], gate["required_fields"])
+    missing_fields = [field for field in required_fields if not fields.get(field, False)]
+    if "title" in required_fields and not _has_meaningful_title(metadata_obj) and "title" not in missing_fields:
+        missing_fields.append("title")
+    min_score = cast(int, gate["min_score"])
+    return {
+        "min_score": min_score,
+        "required_fields": list(required_fields),
+        "missing_fields": missing_fields,
+        "passed": score >= min_score and not missing_fields,
+    }
+
+
+def apply_previous_results(results: List[Dict[str, Any]], previous_data: Dict[str, Any]) -> None:
+    """把上一份结果的状态和评分变化附加到当前结果。"""
+    previous_by_plugin: Dict[str, Dict[str, Any]] = {}
+    previous_results = previous_data.get("results")
+    if isinstance(previous_results, list):
+        for result_value in cast(List[object], previous_results):
+            if not isinstance(result_value, dict):
+                continue
+            previous_result = cast(Dict[str, Any], result_value)
+            plugin_name = previous_result.get("plugin")
+            if plugin_name:
+                previous_by_plugin[str(plugin_name)] = previous_result
+    for result in results:
+        previous = previous_by_plugin.get(str(result["plugin"]))
+        if previous is None:
+            result.update(
+                {
+                    "previous_status": None,
+                    "previous_score": None,
+                    "status_change": "NEW",
+                    "score_change": None,
+                }
+            )
+            continue
+
+        previous_status = str(previous.get("status") or "")
+        previous_score_value = previous.get("score")
+        previous_score = previous_score_value if isinstance(previous_score_value, int) else None
+        current_status = str(result["status"])
+        previous_severity = STATUS_SEVERITY.get(previous_status, 4)
+        current_severity = STATUS_SEVERITY.get(current_status, 4)
+        if current_severity > previous_severity:
+            status_change = "REGRESSED"
+        elif current_status == "OK" and previous_status != "OK":
+            status_change = "RECOVERED"
+        elif previous_status != current_status:
+            status_change = "CHANGED"
+        else:
+            status_change = "UNCHANGED"
+        result.update(
+            {
+                "previous_status": previous_status,
+                "previous_score": previous_score,
+                "status_change": status_change,
+                "score_change": result["score"] - previous_score if previous_score is not None else None,
+            }
+        )
+
+
+def load_previous_results(path: Path) -> Dict[str, Any]:
+    """读取并校验上一份 JSON 测试结果。"""
+    with path.open("r", encoding="utf-8") as file:
+        data: object = json.load(file)
+    if not isinstance(data, dict):
+        raise ValueError(f"上一份结果格式无效: {path}")
+    typed_data = cast(Dict[str, Any], data)
+    if not isinstance(typed_data.get("results"), list):
+        raise ValueError(f"上一份结果格式无效: {path}")
+    return typed_data
+
+
+def select_test_cases(plugin_names: Optional[Set[str]]) -> List[Tuple[str, str, str]]:
+    """按插件名筛选测试样例，并拒绝拼写错误。"""
+    if not plugin_names:
+        return TEST_CASES
+    known_plugins = {case[0] for case in TEST_CASES}
+    unknown_plugins = sorted(plugin_names - known_plugins)
+    if unknown_plugins:
+        raise ValueError(f"未知插件: {', '.join(unknown_plugins)}")
+    return [case for case in TEST_CASES if case[0] in plugin_names]
+
+
+def _get_diagnostic(plugin: Any) -> Dict[str, Any]:
+    getter = getattr(plugin, "get_last_diagnostic", None)
+    if callable(getter):
+        diagnostic = getter()
+        if isinstance(diagnostic, dict):
+            return cast(Dict[str, Any], diagnostic)
+    return {}
+
+
+def _failed_result(
+    plugin_name: str,
+    base_class: str,
+    identifier: str,
+    elapsed: float,
+    attempts: int,
+    diagnostic: Dict[str, Any],
+    status: str = "FAIL",
+) -> Dict[str, Any]:
+    error = str(diagnostic.get("error") or "extract_metadata returned None")
+    return {
+        "plugin": plugin_name,
+        "base_class": base_class,
+        "identifier": identifier,
+        "status": status,
+        "score": 0,
+        "time_ms": round(elapsed),
+        "fields": {},
+        "error": error[:240],
+        "failure_type": classify_failure(diagnostic),
+        "failure_stage": diagnostic.get("stage") or "unknown",
+        "exception_type": diagnostic.get("exception_type"),
+        "http_status": diagnostic.get("http_status"),
+        "final_url": diagnostic.get("final_url"),
+        "attempts": attempts,
+    }
+
+
+def run_tests(plugin_names: Optional[Set[str]] = None, retries: int = 0) -> List[Dict[str, Any]]:
     logging.getLogger("pavone").setLevel(logging.ERROR)
 
     from pavone.manager.plugin_manager import PluginManager
@@ -112,7 +331,7 @@ def run_tests() -> List[Dict[str, Any]]:
     plugin_map = {p.__class__.__name__: p for p in pm.metadata_plugins}
 
     results: List[Dict[str, Any]] = []
-    for plugin_name, base_class, identifier in TEST_CASES:
+    for plugin_name, base_class, identifier in select_test_cases(plugin_names):
         plugin = plugin_map.get(plugin_name)
         if not plugin:
             results.append(
@@ -125,6 +344,9 @@ def run_tests() -> List[Dict[str, Any]]:
                     "time_ms": 0,
                     "fields": {},
                     "error": "Plugin not loaded",
+                    "failure_type": "EMPTY_RESULT",
+                    "failure_stage": "load",
+                    "attempts": 0,
                 }
             )
             continue
@@ -140,61 +362,91 @@ def run_tests() -> List[Dict[str, Any]]:
                     "time_ms": 0,
                     "fields": {},
                     "error": "can_extract returned False",
+                    "failure_type": "STALE_CASE",
+                    "failure_stage": "resolve",
+                    "attempts": 0,
                 }
             )
             continue
 
         start = time.time()
-        try:
-            metadata_obj = plugin.extract_metadata(identifier)
-            elapsed = (time.time() - start) * 1000
-            if metadata_obj is None:
-                results.append(
-                    {
-                        "plugin": plugin_name,
-                        "base_class": base_class,
-                        "identifier": identifier,
-                        "status": "FAIL",
-                        "score": 0,
-                        "time_ms": round(elapsed),
-                        "fields": {},
-                        "error": "extract_metadata returned None",
-                    }
+        attempts = 0
+        metadata_obj = None
+        diagnostic: Dict[str, Any] = {}
+        runner_error: Optional[Exception] = None
+        while attempts <= retries and metadata_obj is None:
+            attempts += 1
+            try:
+                metadata_obj = plugin.extract_metadata(identifier)
+                diagnostic = _get_diagnostic(plugin)
+            except Exception as e:
+                runner_error = e
+                diagnostic = {
+                    "stage": "runner",
+                    "error": str(e),
+                    "exception_type": type(e).__name__,
+                }
+                break
+
+        elapsed = (time.time() - start) * 1000
+        if runner_error is not None:
+            results.append(
+                _failed_result(
+                    plugin_name,
+                    base_class,
+                    identifier,
+                    elapsed,
+                    attempts,
+                    diagnostic,
+                    status="ERROR",
                 )
-            else:
-                score, fields = score_metadata(metadata_obj)
-                results.append(
-                    {
-                        "plugin": plugin_name,
-                        "base_class": base_class,
-                        "identifier": identifier,
-                        "status": "OK",
-                        "score": score,
-                        "time_ms": round(elapsed),
-                        "fields": fields,
-                        "error": None,
-                        "title": getattr(metadata_obj, "title", ""),
-                    }
-                )
-        except Exception as e:
-            elapsed = (time.time() - start) * 1000
+            )
+        elif metadata_obj is None:
+            results.append(_failed_result(plugin_name, base_class, identifier, elapsed, attempts, diagnostic))
+        else:
+            score, fields = score_metadata(metadata_obj)
+            quality_gate = evaluate_quality_gate(plugin_name, metadata_obj, score, fields)
+            gate_passed = quality_gate.get("passed", True)
+            missing_fields = quality_gate.get("missing_fields", [])
+            gate_error_parts: List[str] = []
+            if quality_gate and score < quality_gate["min_score"]:
+                gate_error_parts.append(f"评分 {score} 低于最低分 {quality_gate['min_score']}")
+            if missing_fields:
+                gate_error_parts.append(f"缺少关键字段: {', '.join(missing_fields)}")
             results.append(
                 {
                     "plugin": plugin_name,
                     "base_class": base_class,
                     "identifier": identifier,
-                    "status": "ERROR",
-                    "score": 0,
+                    "status": "OK" if gate_passed else "DEGRADED",
+                    "score": score,
                     "time_ms": round(elapsed),
-                    "fields": {},
-                    "error": str(e)[:120],
+                    "fields": fields,
+                    "error": None if gate_passed else "；".join(gate_error_parts),
+                    "title": getattr(metadata_obj, "title", ""),
+                    "failure_type": None if gate_passed else "QUALITY_GATE",
+                    "failure_stage": None if gate_passed else "quality",
+                    "attempts": attempts,
+                    "quality_gate": quality_gate or None,
                 }
             )
 
         r = results[-1]
-        status_map = {"OK": "  OK", "FAIL": "FAIL", "ERROR": " ERR", "SKIP": "SKIP", "NOT_FOUND": " N/A"}
+        status_map = {
+            "OK": "  OK",
+            "DEGRADED": " DEG",
+            "FAIL": "FAIL",
+            "ERROR": " ERR",
+            "SKIP": "SKIP",
+            "NOT_FOUND": " N/A",
+        }
+        diagnostic_suffix = f" {r.get('failure_type', '')}/{r.get('failure_stage', '')}" if r["status"] != "OK" else ""
+        console_line = (
+            f"  [{status_map.get(r['status'], '????')}] [{r['time_ms']:>5}ms] "
+            + f"{r['plugin']:30s} score={r['score']:>3}{diagnostic_suffix}"
+        )
         print(
-            f"  [{status_map.get(r['status'], '????')}] [{r['time_ms']:>5}ms] " f"{r['plugin']:30s} score={r['score']:>3}",
+            console_line,
             flush=True,
         )
 
@@ -204,6 +456,7 @@ def run_tests() -> List[Dict[str, Any]]:
 def generate_markdown(data: Dict[str, Any]) -> str:
     results = data["results"]
     ok = [r for r in results if r["status"] == "OK"]
+    degraded = [r for r in results if r["status"] == "DEGRADED"]
     fail = [r for r in results if r["status"] == "FAIL"]
     error = [r for r in results if r["status"] == "ERROR"]
     skip = [r for r in results if r["status"] == "SKIP"]
@@ -213,12 +466,14 @@ def generate_markdown(data: Dict[str, Any]) -> str:
         f"\n**测试时间**: {data['timestamp']}",
         f"**总耗时**: {data['total_time_s']}s",
         f"**测试插件数**: {len(results)}",
+        f"**跟踪 Issue**: [#{TRACKING_ISSUE_URL.rsplit('/', 1)[-1]}]({TRACKING_ISSUE_URL})",
         "",
         "## 概览",
         "",
         "| 状态 | 数量 |",
         "|------|------|",
         f"| ✅ 成功 | {len(ok)} |",
+        f"| ⚠️ 质量降级 | {len(degraded)} |",
         f"| ❌ 提取失败 | {len(fail)} |",
         f"| 💥 异常 | {len(error)} |",
         f"| ⏭️ 跳过 | {len(skip)} |",
@@ -230,18 +485,56 @@ def generate_markdown(data: Dict[str, Any]) -> str:
         lines.append(f"\n**成功插件平均完整度评分**: {avg_score:.1f}/100")
         lines.append(f"**成功插件平均响应时间**: {avg_time:.0f}ms")
 
+    has_previous = any("previous_status" in result for result in results)
+    if has_previous:
+        regressions = [result for result in results if result.get("status_change") == "REGRESSED"]
+        recoveries = [result for result in results if result.get("status_change") == "RECOVERED"]
+        score_drops = [
+            result
+            for result in results
+            if isinstance(result.get("score_change"), int) and result["score_change"] <= -SIGNIFICANT_SCORE_DROP
+        ]
+        lines += ["", "## 趋势", ""]
+        if not regressions and not recoveries and not score_drops:
+            lines.append("- 无新增失败、恢复或显著降分。")
+        for result in regressions:
+            lines.append(f"- 🚨 **新增失败/降级**: {result['plugin']} ({result['previous_status']} → {result['status']})")
+        for result in recoveries:
+            lines.append(f"- 🎉 **恢复**: {result['plugin']} ({result['previous_status']} → {result['status']})")
+        for result in score_drops:
+            lines.append(
+                "- 📉 **显著降分**: {} ({} → {}, {:+d})".format(
+                    result["plugin"],
+                    result["previous_score"],
+                    result["score"],
+                    result["score_change"],
+                )
+            )
+
     lines += [
         "",
         "## 详细结果",
         "",
-        "| # | 插件 | 基类 | 状态 | 评分 | 耗时 | 说明 |",
-        "|---|------|------|------|------|------|------|",
+        "| # | 插件 | 基类 | 状态 | 分类/阶段 | 评分 | 耗时 | 说明 |",
+        "|---|------|------|------|-----------|------|------|------|",
     ]
 
     for i, r in enumerate(results, 1):
-        icon = {"OK": "✅", "FAIL": "❌", "ERROR": "💥", "SKIP": "⏭️", "NOT_FOUND": "❓"}[r["status"]]
+        icon = {"OK": "✅", "DEGRADED": "⚠️", "FAIL": "❌", "ERROR": "💥", "SKIP": "⏭️", "NOT_FOUND": "❓"}[r["status"]]
         note = r.get("title", "")[:40] if r["status"] == "OK" else (r.get("error", "")[:50] or "")
-        lines.append(f"| {i} | {r['plugin']} | {r['base_class']} | {icon} | {r['score']} | {r['time_ms']}ms | {note} |")
+        failure = f"{r.get('failure_type', '')}/{r.get('failure_stage', '')}" if r["status"] != "OK" else "-"
+        lines.append(
+            "| {} | {} | {} | {} | {} | {} | {}ms | {} |".format(
+                i,
+                r["plugin"],
+                r["base_class"],
+                icon,
+                failure,
+                r["score"],
+                r["time_ms"],
+                note,
+            )
+        )
 
     if ok:
         lines += [
@@ -260,18 +553,36 @@ def generate_markdown(data: Dict[str, Any]) -> str:
         for i, r in enumerate(sorted(ok, key=lambda x: (-x["score"], x["time_ms"])), 1):
             lines.append(f"| {i} | {r['plugin']} | {r['base_class']} | {r['score']}/100 | {r['time_ms']}ms |")
 
-    if fail or error:
-        lines += ["", "## 失败/异常插件", ""]
-        for r in fail + error:
-            lines.append(f"- **{r['plugin']}** ({r['base_class']}): {r['error']}")
+    if degraded or fail or error:
+        lines += ["", "## 降级/失败/异常插件", ""]
+        for r in degraded + fail + error:
+            context: List[str] = []
+            if r.get("http_status") is not None:
+                context.append(f"HTTP {r['http_status']}")
+            if r.get("final_url"):
+                context.append(str(r["final_url"]))
+            context_text = f"；{'；'.join(context)}" if context else ""
+            lines.append(
+                "- **{}** ({}): `{}/{}` {}{}".format(
+                    r["plugin"],
+                    r["base_class"],
+                    r.get("failure_type", "UNKNOWN"),
+                    r.get("failure_stage", "unknown"),
+                    r["error"],
+                    context_text,
+                )
+            )
 
     return "\n".join(lines)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="PAVOne 元数据插件全量集成测试")
     parser.add_argument("--output-dir", type=str, default=None, help="输出目录 (默认: 当前目录)")
     parser.add_argument("--format", type=str, choices=["json", "markdown", "both"], default="both", help="输出格式")
+    parser.add_argument("--plugin", action="append", dest="plugins", help="仅运行指定插件，可重复提供")
+    parser.add_argument("--retries", type=int, choices=range(0, 3), default=0, help="失败重试次数（0-2）")
+    parser.add_argument("--previous-results", type=Path, default=None, help="上一份 JSON 结果，用于生成趋势")
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir) if args.output_dir else Path.cwd()
@@ -289,10 +600,18 @@ def main():
     print("=" * 60)
 
     total_start = time.time()
-    results = run_tests()
+    try:
+        results = run_tests(set(args.plugins) if args.plugins else None, retries=args.retries)
+    except ValueError as e:
+        parser.error(str(e))
     total_elapsed = time.time() - total_start
+    if args.previous_results is not None:
+        try:
+            apply_previous_results(results, load_previous_results(args.previous_results))
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            print(f"警告: 无法读取上一份结果，跳过趋势比较: {error}", file=sys.stderr)
 
-    data = {
+    data: Dict[str, Any] = {
         "version": version,
         "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         "total_time_s": round(total_elapsed, 1),
@@ -300,12 +619,13 @@ def main():
     }
 
     ok = [r for r in results if r["status"] == "OK"]
+    degraded = [r for r in results if r["status"] == "DEGRADED"]
     fail = [r for r in results if r["status"] == "FAIL"]
     error = [r for r in results if r["status"] == "ERROR"]
 
     print()
     print("=" * 60)
-    print(f"总计: {len(results)} | 成功: {len(ok)} | 失败: {len(fail)} | 异常: {len(error)}")
+    print(f"总计: {len(results)} | 成功: {len(ok)} | 降级: {len(degraded)} | 失败: {len(fail)} | 异常: {len(error)}")
     print(f"总耗时: {total_elapsed:.1f}s")
     if ok:
         avg_score = sum(r["score"] for r in ok) / len(ok)

--- a/tests/metadata/test_fc2ppvdb.py
+++ b/tests/metadata/test_fc2ppvdb.py
@@ -24,6 +24,7 @@ class TestFc2PpvdbMetadata:
 
     def test_cannot_extract_invalid(self):
         assert not self.extractor.can_extract("https://example.com/articles/123")
+        assert not self.extractor.can_extract("https://fc2ppv-db.com/ja/videos/4669533")
         assert not self.extractor.can_extract("abc")
         assert not self.extractor.can_extract("")
 

--- a/tests/metadata/test_gcolle.py
+++ b/tests/metadata/test_gcolle.py
@@ -8,6 +8,8 @@ Gcolle 元数据提取器测试
 
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from pavone.plugins.metadata.gcolle_metadata import GcolleMetadata
 
 
@@ -28,10 +30,11 @@ class TestGcolleMetadata:
         assert not self.extractor.can_extract("")
 
     def _mock_html_response(self):
-        with open("tests/sites/gcolle.html", "r", encoding="utf-8") as f:
+        with open("tests/sites/gcolle_product.html", "r", encoding="utf-8") as f:
             html = f.read()
         mock = MagicMock()
         mock.status_code = 200
+        mock.url = "https://gcolle.net/product_info.php/products_id/847256"
         mock.content = html.encode("utf-8")
         mock.text = html
         mock.raise_for_status = MagicMock()
@@ -45,6 +48,13 @@ class TestGcolleMetadata:
 
         assert metadata is not None
         assert "GCOLLE-847256" in metadata.code
+        assert "電車XX #22" in metadata.title
+        assert metadata.plot is not None and "商品説明" in metadata.plot
+        assert metadata.studio == "4号車"
+        assert metadata.premiered == "2022-06-03"
+        assert metadata.tags is not None and "個人撮影" in metadata.tags
+        assert metadata.cover == "https://img.gcolle.net/uploader/original/21651/cover.jpg"
+        assert metadata.backdrops == ["https://img.gcolle.net/uploader/sample/21651/sample01.jpg"]
         assert metadata.official_rating == "JP-18+"
 
     def test_extract_metadata_from_id(self):
@@ -55,3 +65,40 @@ class TestGcolleMetadata:
 
     def test_extract_metadata_invalid(self):
         assert self.extractor.extract_metadata("https://example.com/") is None
+
+    def test_age_check_page_is_not_metadata(self):
+        with open("tests/sites/gcolle.html", "r", encoding="utf-8") as f:
+            html = f.read()
+        response = MagicMock()
+        response.status_code = 200
+        response.url = "https://gcolle.net/age_check.php/continue/token"
+        response.text = html
+
+        with patch.object(self.extractor, "_fetch_page", return_value=response):
+            assert self.extractor.extract_metadata("847256") is None
+
+    def test_fetch_page_follows_age_confirmation_with_redirect_cookie(self):
+        with open("tests/sites/gcolle.html", "r", encoding="utf-8") as f:
+            age_html = f.read()
+
+        redirect = requests.Response()
+        redirect.status_code = 302
+        redirect.cookies.set("osCsid", "session-token")
+
+        age_response = requests.Response()
+        age_response.status_code = 200
+        age_response.url = "https://gcolle.net/age_check.php/continue/token"
+        age_response.encoding = "utf-8"
+        age_response._content = age_html.encode("utf-8")
+        age_response.history = [redirect]
+
+        product_response = self._mock_html_response()
+        with patch.object(self.extractor, "fetch", side_effect=[age_response, product_response]) as fetch:
+            result = self.extractor._fetch_page("https://gcolle.net/product_info.php/products_id/847256")
+
+        assert result is product_response
+        assert fetch.call_count == 2
+        follow_up = fetch.call_args_list[1]
+        assert "age_check" in follow_up.args[0]
+        assert follow_up.kwargs["cookies"] == {"osCsid": "session-token"}
+        assert follow_up.kwargs["headers"]["Referer"] == age_response.url

--- a/tests/sites/gcolle_product.html
+++ b/tests/sites/gcolle_product.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <title>Gcolle product</title>
+  </head>
+  <body>
+    <form id="cart_quantity">
+      <h1>【電車XX #22】スレンダー販売員</h1>
+      <p class="rating"></p>
+      <p>風の強いある日、街でいつものように獲物を物色中。これは商品説明です。</p>
+      <a href="//img.gcolle.net/uploader/original/21651/cover.jpg">
+        <img src="//img.gcolle.net/uploader/200x200/21651/cover.jpg" alt="cover">
+      </a>
+      <a href="/search.php/genre/12">個人撮影</a>
+      <div>
+        <img src="//img.gcolle.net/uploader/sample/21651/sample01.jpg" alt="sample">
+      </div>
+      <table class="filesetumei">
+        <tr>
+          <td>商品登録日</td>
+          <td>2022年6月3日</td>
+        </tr>
+      </table>
+      <table class="contentBoxContentsManufactureInfo">
+        <tr>
+          <td>アップロード会員名：<b>4号車</b></td>
+        </tr>
+      </table>
+    </form>
+  </body>
+</html>

--- a/tests/test_http_utils_retry.py
+++ b/tests/test_http_utils_retry.py
@@ -57,6 +57,23 @@ def test_fetch_4xx_with_skip_callback_does_not_retry(mock_get: MagicMock) -> Non
 
 
 @patch("pavone.utils.http_utils.requests.get")
+def test_fetch_preserves_original_http_error_response(mock_get: MagicMock) -> None:
+    resp = _make_resp(403)
+    err = requests.HTTPError("403 Client Error", response=resp)
+    mock_get.return_value = MagicMock(raise_for_status=MagicMock(side_effect=err))
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        HttpUtils.fetch(
+            _download_cfg(),
+            ProxyConfig(),
+            "https://example.com/x",
+            max_retry=1,
+        )
+
+    assert exc_info.value.response is resp
+
+
+@patch("pavone.utils.http_utils.requests.get")
 def test_fetch_5xx_with_skip_callback_still_retries(mock_get: MagicMock) -> None:
     """skip_retry_on_4xx 只对 4xx 生效，5xx 仍重试。"""
     resp = _make_resp(503)

--- a/tests/test_metadata_diagnostics.py
+++ b/tests/test_metadata_diagnostics.py
@@ -1,0 +1,336 @@
+from types import SimpleNamespace
+from typing import Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+import requests
+from bs4 import BeautifulSoup
+
+from pavone.models import BaseMetadata
+from pavone.plugins.metadata.avbase_metadata import AvBaseMetadata
+from pavone.plugins.metadata.base import ApiMetadataPlugin, HtmlMetadataPlugin, MetadataPlugin
+from pavone.plugins.metadata.fanza_metadata import FanzaMetadata
+from pavone.plugins.metadata.supfc2_metadata import SupFC2Metadata
+from scripts import test_metadata_plugins
+from scripts.test_metadata_plugins import (
+    QUALITY_GATES,
+    _has_meaningful_title,
+    apply_previous_results,
+    classify_failure,
+    generate_markdown,
+    run_tests,
+    select_test_cases,
+)
+
+
+class _DiagnosticPlugin(HtmlMetadataPlugin):
+    def can_extract(self, identifier: str) -> bool:
+        return True
+
+    def _resolve(self, identifier: str) -> Tuple[Optional[str], Optional[str]]:
+        return "movie-id", "https://example.com/movie-id"
+
+    def _parse(self, soup: BeautifulSoup, movie_id: str, page_url: str) -> Optional[BaseMetadata]:
+        return None
+
+
+class _ApiDiagnosticPlugin(ApiMetadataPlugin):
+    def can_extract(self, identifier: str) -> bool:
+        return True
+
+    def _resolve(self, identifier: str) -> Tuple[Optional[str], Optional[str]]:
+        return "movie-id", "https://example.com/movie-id"
+
+    def _build_api_url(self, movie_id: str) -> str:
+        return "https://example.com/api/movie-id"
+
+    def _parse(self, data: dict[str, object], movie_id: str, page_url: str) -> Optional[BaseMetadata]:
+        return None
+
+
+def _response(status: int = 200) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response.url = "https://example.com/final"
+    response._content = b"<html></html>"
+    response.encoding = "utf-8"
+    return response
+
+
+def test_html_plugin_records_parse_diagnostic() -> None:
+    plugin = _DiagnosticPlugin()
+    with patch.object(plugin, "_fetch_page", return_value=_response()):
+        assert plugin.extract_metadata("movie-id") is None
+
+    diagnostic = plugin.get_last_diagnostic()
+    assert diagnostic["stage"] == "parse"
+    assert diagnostic["error"] == "解析器返回空结果"
+    assert diagnostic["http_status"] == 200
+    assert diagnostic["final_url"] == "https://example.com/final"
+
+
+def test_html_plugin_records_http_failure() -> None:
+    plugin = _DiagnosticPlugin()
+    response = _response(403)
+    error = requests.HTTPError("403 Client Error", response=response)
+    with patch.object(plugin, "_fetch_page", side_effect=error):
+        assert plugin.extract_metadata("movie-id") is None
+
+    diagnostic = plugin.get_last_diagnostic()
+    assert diagnostic["stage"] == "fetch"
+    assert diagnostic["exception_type"] == "HTTPError"
+    assert diagnostic["http_status"] == 403
+    assert classify_failure(diagnostic) == "BLOCKED"
+
+
+def test_api_json_decode_failure_is_parse_diagnostic() -> None:
+    plugin = _ApiDiagnosticPlugin()
+    response = _response()
+    with (
+        patch.object(plugin, "_fetch_api", return_value=response),
+        patch.object(response, "json", side_effect=ValueError("invalid json")),
+    ):
+        assert plugin.extract_metadata("movie-id") is None
+
+    diagnostic = plugin.get_last_diagnostic()
+    assert diagnostic["stage"] == "parse"
+    assert diagnostic["exception_type"] == "ValueError"
+    assert classify_failure(diagnostic) == "PARSE"
+
+
+@pytest.mark.parametrize("plugin_class", [AvBaseMetadata, FanzaMetadata, SupFC2Metadata])
+def test_overridden_extractors_record_resolve_diagnostic(plugin_class: type[MetadataPlugin]) -> None:
+    plugin = plugin_class()
+    assert plugin.extract_metadata("https://example.com/invalid") is None
+    diagnostic = plugin.get_last_diagnostic()
+    assert diagnostic["stage"] == "resolve"
+    assert diagnostic["error"]
+
+
+@pytest.mark.parametrize(
+    ("diagnostic", "expected"),
+    [
+        ({"stage": "resolve", "error": "bad id"}, "STALE_CASE"),
+        ({"stage": "fetch", "error": "404 Client Error"}, "STALE_CASE"),
+        ({"stage": "fetch", "error": "connection timed out"}, "NETWORK"),
+        ({"stage": "fetch", "error": "403 forbidden", "http_status": 403}, "BLOCKED"),
+        ({"stage": "parse", "error": "selector missing", "http_status": 200}, "PARSE"),
+        ({"stage": "unknown", "error": "no details"}, "EMPTY_RESULT"),
+    ],
+)
+def test_classify_failure(diagnostic: dict[str, object], expected: str) -> None:
+    assert classify_failure(diagnostic) == expected
+
+
+def test_select_test_cases_rejects_unknown_plugin() -> None:
+    with pytest.raises(ValueError, match="未知插件"):
+        select_test_cases({"MissingMetadata"})
+
+
+def test_run_tests_retries_selected_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePlugin:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def can_extract(self, identifier: str) -> bool:
+            return True
+
+        def extract_metadata(self, identifier: str) -> object | None:
+            self.calls += 1
+            if self.calls == 1:
+                return None
+            return SimpleNamespace(title="Recovered")
+
+        def get_last_diagnostic(self) -> dict[str, object]:
+            return {"stage": "fetch", "error": "connection timed out"}
+
+    plugin = FakePlugin()
+    manager = SimpleNamespace(load_plugins=lambda: None, metadata_plugins=[plugin])
+    monkeypatch.setattr(test_metadata_plugins, "TEST_CASES", [("FakePlugin", "Html", "id")])
+    with patch("pavone.manager.plugin_manager.PluginManager", return_value=manager):
+        results = run_tests({"FakePlugin"}, retries=1)
+
+    assert results[0]["status"] == "OK"
+    assert results[0]["attempts"] == 2
+    assert plugin.calls == 2
+
+
+def test_quality_gate_marks_returned_metadata_as_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeTokyoHotPlugin:
+        def can_extract(self, identifier: str) -> bool:
+            return True
+
+        def extract_metadata(self, identifier: str) -> object:
+            return SimpleNamespace(title="n0697", code="n0697", cover="cover.jpg", premiered=None, studio="TOKYO-HOT")
+
+    manager = SimpleNamespace(load_plugins=lambda: None, metadata_plugins=[FakeTokyoHotPlugin()])
+    monkeypatch.setattr(
+        test_metadata_plugins,
+        "TEST_CASES",
+        [("FakeTokyoHotPlugin", "Html", "https://my.tokyo-hot.com/product/n0697/?lang=ja")],
+    )
+    monkeypatch.setitem(QUALITY_GATES, "FakeTokyoHotPlugin", QUALITY_GATES["TokyoHotMetadata"])
+    with patch("pavone.manager.plugin_manager.PluginManager", return_value=manager):
+        results = run_tests({"FakeTokyoHotPlugin"})
+
+    assert results[0]["status"] == "DEGRADED"
+    assert results[0]["failure_type"] == "QUALITY_GATE"
+    assert results[0]["quality_gate"]["missing_fields"] == ["premiered", "title"]
+    assert results[0]["quality_gate"]["min_score"] == 70
+
+
+def test_title_with_code_and_descriptive_text_is_meaningful() -> None:
+    metadata = SimpleNamespace(code="FC2-2941579", title="FC2-2941579 あどけない顔をした美少女")
+
+    assert _has_meaningful_title(metadata)
+
+
+def test_title_with_only_repeated_code_is_not_meaningful() -> None:
+    metadata = SimpleNamespace(code="n0697", title="n0697 n0697")
+
+    assert not _has_meaningful_title(metadata)
+
+
+@pytest.mark.parametrize(
+    ("plugin_name", "min_score", "required_fields"),
+    [
+        ("TokyoHotMetadata", 70, {"title", "cover", "premiered", "studio"}),
+        ("PcolleMetadata", 50, {"title", "cover", "premiered", "studio", "plot"}),
+        ("MyWifeMetadata", 45, {"title", "cover", "studio"}),
+        ("PPVDataBankMetadata", 30, {"title", "cover", "premiered", "studio"}),
+        ("JavfreeMetadata", 25, {"title", "cover", "premiered", "director"}),
+    ],
+)
+def test_quality_gate_definitions(plugin_name: str, min_score: int, required_fields: set[str]) -> None:
+    assert QUALITY_GATES[plugin_name]["min_score"] == min_score
+    assert set(QUALITY_GATES[plugin_name]["required_fields"]) == required_fields
+
+
+def test_apply_previous_results_records_trends() -> None:
+    results = [
+        {"plugin": "Regressed", "status": "DEGRADED", "score": 55},
+        {"plugin": "Worsened", "status": "FAIL", "score": 0},
+        {"plugin": "Recovered", "status": "OK", "score": 60},
+        {"plugin": "NewPlugin", "status": "OK", "score": 50},
+    ]
+    previous = {
+        "results": [
+            {"plugin": "Regressed", "status": "OK", "score": 80},
+            {"plugin": "Worsened", "status": "DEGRADED", "score": 40},
+            {"plugin": "Recovered", "status": "FAIL", "score": 0},
+        ]
+    }
+
+    apply_previous_results(results, previous)
+
+    assert results[0]["previous_status"] == "OK"
+    assert results[0]["previous_score"] == 80
+    assert results[0]["status_change"] == "REGRESSED"
+    assert results[0]["score_change"] == -25
+    assert results[1]["status_change"] == "REGRESSED"
+    assert results[2]["status_change"] == "RECOVERED"
+    assert results[2]["score_change"] == 60
+    assert results[3]["status_change"] == "NEW"
+    assert results[3]["score_change"] is None
+
+
+@pytest.mark.parametrize("current_status", ["DEGRADED", "SKIP", "NOT_FOUND"])
+def test_non_ok_improvement_is_not_reported_as_recovered(current_status: str) -> None:
+    results = [{"plugin": "StillUnhealthy", "status": current_status, "score": 20}]
+    previous = {"results": [{"plugin": "StillUnhealthy", "status": "FAIL", "score": 0}]}
+
+    apply_previous_results(results, previous)
+
+    assert results[0]["status_change"] == "CHANGED"
+
+
+def test_markdown_without_previous_results_remains_compatible() -> None:
+    markdown = generate_markdown(
+        {
+            "version": "1.0.0",
+            "timestamp": "2026-07-24",
+            "total_time_s": 1,
+            "results": [],
+        }
+    )
+
+    assert "## 趋势" not in markdown
+    assert "质量降级 | 0" in markdown
+    assert "[#126](https://github.com/imbatony/pavone/issues/126)" in markdown
+
+
+def test_markdown_highlights_trends() -> None:
+    results = [
+        {
+            "plugin": "Regressed",
+            "base_class": "Html",
+            "status": "DEGRADED",
+            "score": 55,
+            "time_ms": 100,
+            "fields": {},
+            "error": "评分过低",
+            "failure_type": "QUALITY_GATE",
+            "failure_stage": "quality",
+        },
+        {
+            "plugin": "Recovered",
+            "base_class": "Html",
+            "status": "OK",
+            "score": 60,
+            "time_ms": 100,
+            "fields": {},
+            "error": None,
+            "title": "Recovered title",
+        },
+    ]
+    apply_previous_results(
+        results,
+        {
+            "results": [
+                {"plugin": "Regressed", "status": "OK", "score": 80},
+                {"plugin": "Recovered", "status": "FAIL", "score": 0},
+            ]
+        },
+    )
+
+    markdown = generate_markdown(
+        {
+            "version": "1.0.0",
+            "timestamp": "2026-07-24",
+            "total_time_s": 1,
+            "results": results,
+        }
+    )
+
+    assert "**新增失败/降级**: Regressed (OK → DEGRADED)" in markdown
+    assert "**恢复**: Recovered (FAIL → OK)" in markdown
+    assert "**显著降分**: Regressed (80 → 55, -25)" in markdown
+
+
+def test_markdown_includes_failure_diagnostics() -> None:
+    markdown = generate_markdown(
+        {
+            "version": "1.0.0",
+            "timestamp": "2026-07-24",
+            "total_time_s": 1,
+            "results": [
+                {
+                    "plugin": "BlockedMetadata",
+                    "base_class": "Html",
+                    "status": "FAIL",
+                    "score": 0,
+                    "time_ms": 100,
+                    "fields": {},
+                    "error": "403 Client Error",
+                    "failure_type": "BLOCKED",
+                    "failure_stage": "fetch",
+                    "http_status": 403,
+                    "final_url": "https://example.com/final",
+                }
+            ],
+        }
+    )
+
+    assert "BLOCKED/fetch" in markdown
+    assert "HTTP 403" in markdown
+    assert "https://example.com/final" in markdown


### PR DESCRIPTION
## 变更概述

增强元数据插件每日测试的可诊断性和稳定性：公共基类及自定义提取器现在记录失败阶段、HTTP 状态、最终 URL 与异常；测试脚本支持插件筛选、有限重试、失败分类、质量门禁和跨日报告趋势。

同时修复 Gcolle 年龄确认 Cookie 流程，更新失效的 Gcolle、Heydouga 与 TokyoHot 样例，补充新 Fc2ppvDb 域名覆盖，并让非 headless 浏览器测试通过 Xvfb 在 CI 中运行。真实复测中原 14 个失败插件有 9 个恢复，剩余站点已明确归类为封锁、失效样例或外部网络问题。

## Release Notes

<!-- release-notes:start -->
### 修复
- 修复 Gcolle 年龄确认页导致元数据提取失败的问题。

### 改进
- 元数据每日测试现在会展示失败分类、诊断上下文、质量降级和相对上一日的趋势。
- 元数据测试支持按插件筛选与有限重试，便于排查外部站点波动。
<!-- release-notes:end -->

## 验证

- [x] 已完成与改动对应的验证
- [x] 已添加或更新必要测试

- `uv run --frozen pytest tests\metadata tests\test_metadata_diagnostics.py tests\test_http_utils_retry.py tests\test_supfc2_metadata.py -q`
- `uv run --frozen black --check ...`
- `uv run --frozen isort --check-only ...`
- `uv run --frozen flake8 --extend-ignore=C901 ...`
- `uv run --frozen pyright pavone\ scripts\test_metadata_plugins.py`
- 工作流 YAML 解析检查

## 关联事项

Fixes #122
Fixes #123
Fixes #124
Fixes #125
Related to #126

## 发布级别

默认 patch。

## 提交前检查

- [x] PR 标题符合 `type(scope)!: description`
- [x] Release Notes 使用中文描述用户可感知变化，或已添加 `release:skip`
- [x] major 变更包含 `### 重大变更` 和迁移说明（不适用）
- [x] 未手动修改版本号或新增 CHANGELOG 版本条目